### PR TITLE
Output and command improvements for Win10

### DIFF
--- a/lib/rex/powershell/command.rb
+++ b/lib/rex/powershell/command.rb
@@ -158,13 +158,17 @@ module Command
         when :noprofile
           arg_string << '-NoProfile ' if value
         when :windowstyle
-          arg_string << "-WindowStyle #{value} " if  value
+          arg_string << "-WindowStyle #{value} " if value
       end
     end
 
     # Command must be last (unless from stdin - etc)
     if opts[:command]
-      arg_string << "-Command #{opts[:command]}"
+      if opts[:use_single_quotes]
+        arg_string << "-Command #{opts[:command]}"
+      else
+        arg_string << "-Command \"#{opts[:command]}\""
+      end
     end
 
     # Shorten arg if PSH 2.0+
@@ -214,8 +218,10 @@ module Command
 
     if encoded
       opts[:encodedcommand] = ps_code
-    else
+    elsif opts[:use_single_quotes]
       opts[:command] = ps_code.gsub("'", "''")
+    else
+      opts[:command] = ps_code
     end
 
     ps_args = generate_psh_args(opts)
@@ -283,17 +289,17 @@ EOS
     end
 
     psh_payload = case opts[:method]
-                    when 'net'
-                      Rex::Powershell::Payload.to_win32pe_psh_net(template_path, pay)
-                    when 'reflection'
-                      Rex::Powershell::Payload.to_win32pe_psh_reflection(template_path, pay)
-                    when 'old'
-                      Rex::Powershell::Payload.to_win32pe_psh(template_path, pay)
-                    when 'msil'
-                      fail RuntimeError, 'MSIL Powershell method no longer exists'
-                    else
-                      fail RuntimeError, 'No Powershell method specified'
-                  end
+      when 'net'
+        Rex::Powershell::Payload.to_win32pe_psh_net(template_path, pay)
+      when 'reflection'
+        Rex::Powershell::Payload.to_win32pe_psh_reflection(template_path, pay)
+      when 'old'
+        Rex::Powershell::Payload.to_win32pe_psh(template_path, pay)
+      when 'msil'
+        fail RuntimeError, 'MSIL Powershell method no longer exists'
+      else
+        fail RuntimeError, 'No Powershell method specified'
+    end
 
     # Run our payload in a while loop
     if opts[:persist]

--- a/spec/rex/powershell/command_spec.rb
+++ b/spec/rex/powershell/command_spec.rb
@@ -393,8 +393,13 @@ RSpec.describe Rex::Powershell::Command do
           expect(long_args[-1]).not_to eql " "
 
           if opts[:command]
-            expect(long_args[-10..-1]).to eql "-Command Z"
-            expect(short_args[-4..-1]).to eql "-c Z"
+            if opts[:use_single_quotes]
+              expect(long_args[-10..-1]).to eql "-Command Z"
+              expect(short_args[-4..-1]).to eql "-c Z"
+            else
+              expect(long_args[-12..-1]).to eql "-Command \"Z\""
+              expect(short_args[-6..-1]).to eql "-c \"Z\""
+            end
           end
        end
       end


### PR DESCRIPTION
Newer versions of windows implement script filtering approaches to
block and log PowerShell execution which appears suspicious. The
Rex::Powershell::Output decompressors utilize invoke-expression as
"IEX" which makes these defenses unhappy.
Convert the gzip decompressor mechanism to stop using inline vars,
drop the IEX invocation, and replace it with &(scriptblock), where
the scriptblock is generated from the existing stream processors
which have been reformatted for inline delivery of content from the
compressed payload into the scriptblock as text.

Rex::Powershell::Command did not properly address the single quotes
option when generating arguments for command execution.
When use_single_quotes is not true, double quote wrap the argument
to -Command when and prevent escaping of single quotes