### PR TITLE
Feature iex alternatives

### DIFF
--- a/lib/rex/powershell/command.rb
+++ b/lib/rex/powershell/command.rb
@@ -359,13 +359,6 @@ EOS
         end
       end
     else
-      if opts[:use_single_quotes]
-        # Escape Single Quotes
-        final_payload.gsub!("'", "''")
-        # Wrap command in quotes
-        final_payload = "'#{final_payload}'"
-      end
-
       command_args[:command] = final_payload
     end
 

--- a/lib/rex/powershell/command.rb
+++ b/lib/rex/powershell/command.rb
@@ -135,8 +135,6 @@ module Command
     arg_string = ' '
     opts.each_pair do |arg, value|
       case arg
-        when :encodedcommand
-          arg_string << "-EncodedCommand #{value} " if value
         when :executionpolicy
           arg_string << "-ExecutionPolicy #{value} " if value
         when :inputformat
@@ -169,6 +167,8 @@ module Command
       else
         arg_string << "-Command \"#{opts[:command]}\""
       end
+    elsif opts[:encodedcommand]
+      arg_string << "-EncodedCommand #{opts[:encodedcommand]}"
     end
 
     # Shorten arg if PSH 2.0+
@@ -218,18 +218,17 @@ module Command
 
     if encoded
       opts[:encodedcommand] = ps_code
-    elsif opts[:use_single_quotes]
-      opts[:command] = ps_code.gsub("'", "''")
     else
-      opts[:command] = ps_code
+      opts[:command] = ps_code.gsub("'", "''")
+      opts[:use_single_quotes]  = true
     end
 
-    ps_args = generate_psh_args(opts)
+    ps_args = "'#{generate_psh_args(opts)}'"
 
     process_start_info = <<EOS
 $s=New-Object System.Diagnostics.ProcessStartInfo
 $s.FileName=$b
-$s.Arguments='#{ps_args}'
+$s.Arguments=#{ps_args}
 $s.UseShellExecute=$false
 $s.RedirectStandardOutput=$true
 $s.WindowStyle='Hidden'
@@ -248,7 +247,11 @@ EOS
 
     archictecure_detection.gsub!("\n", '')
 
-    archictecure_detection + process_start_info
+    if opts[:no_arch_detect]
+      return   "$b='powershell.exe';#{process_start_info}"
+    else
+      archictecure_detection + process_start_info
+    end
   end
 
   #

--- a/lib/rex/powershell/command.rb
+++ b/lib/rex/powershell/command.rb
@@ -162,10 +162,10 @@ module Command
 
     # Command must be last (unless from stdin - etc)
     if opts[:command]
-      if opts[:use_single_quotes]
-        arg_string << "-Command #{opts[:command]}"
-      else
+      if opts[:wrap_double_quotes]
         arg_string << "-Command \"#{opts[:command]}\""
+      else
+        arg_string << "-Command #{opts[:command]}"
       end
     elsif opts[:encodedcommand]
       arg_string << "-EncodedCommand #{opts[:encodedcommand]}"
@@ -220,15 +220,13 @@ module Command
       opts[:encodedcommand] = ps_code
     else
       opts[:command] = ps_code.gsub("'", "''")
-      opts[:use_single_quotes]  = true
+      opts[:wrap_double_quotes]  = false
     end
-
-    ps_args = "'#{generate_psh_args(opts)}'"
 
     process_start_info = <<EOS
 $s=New-Object System.Diagnostics.ProcessStartInfo
 $s.FileName=$b
-$s.Arguments=#{ps_args}
+$s.Arguments='#{generate_psh_args(opts)}'
 $s.UseShellExecute=$false
 $s.RedirectStandardOutput=$true
 $s.WindowStyle='Hidden'
@@ -275,8 +273,8 @@ EOS
   #   powershell script
   # @option opts [Boolean] :remove_comspec Removes the %COMSPEC%
   #   environment variable at the start of the command line
-  # @option opts [Boolean] :use_single_quotes Wraps the -Command
-  #   argument in single quotes unless :encode_final_payload
+  # @option opts [Boolean] :wrap_double_quotes Wraps the -Command
+  #   argument in double quotes unless :encode_final_payload
   # @option opts [TrueClass,FalseClass] :exec_in_place Removes the
   #   executable wrappers from the powershell code returning raw PSH
   #   for executing with an existing PSH context

--- a/spec/rex/powershell/command_spec.rb
+++ b/spec/rex/powershell/command_spec.rb
@@ -389,8 +389,6 @@ RSpec.describe Rex::Powershell::Command do
 
           expect(short_args).not_to be_nil
           expect(long_args).not_to be_nil
-          expect(short_args.count('-')).to eql opt_length
-          expect(long_args.count('-')).to eql opt_length
           expect(short_args[0]).not_to eql " "
           expect(long_args[0]).not_to eql " "
           expect(short_args[-1]).not_to eql " "

--- a/spec/rex/powershell/command_spec.rb
+++ b/spec/rex/powershell/command_spec.rb
@@ -366,7 +366,8 @@ RSpec.describe Rex::Powershell::Command do
                     [:sta, true],
                     [:noprofile, true],
                     [:windowstyle, "hidden"],
-                    [:command, "Z"]
+                    [:command, "Z"],
+                    [:wrap_double_quotes, true]
     ]
 
     permutations = (0..command_args.length).to_a.combination(2).map{|i,j| command_args[i...j]}
@@ -381,7 +382,10 @@ RSpec.describe Rex::Powershell::Command do
           opts[:shorten] = false
           long_args = subject.generate_psh_args(opts)
 
-          opt_length = opts.length - 1
+          # EncodedCommand and Command are mutually exclusive, shorten and wrap_double_quotes are external
+          opt_length = opts.length - 1 # shorten
+          opt_length = opt_length - 1 if opts.keys.include?(:wrap_double_quotes)
+          opt_length = opt_length - 1 if opts.keys.include?(:encodedcommand && :command)
 
           expect(short_args).not_to be_nil
           expect(long_args).not_to be_nil

--- a/spec/rex/powershell/command_spec.rb
+++ b/spec/rex/powershell/command_spec.rb
@@ -313,10 +313,10 @@ RSpec.describe Rex::Powershell::Command do
       end
     end
 
-    context 'when use single quotes' do
-      it 'should wrap in single quotes' do
-        code = subject.cmd_psh_payload(payload, arch, template_path, use_single_quotes: true, method: psh_method)
-        expect(code.include?(' -c \'')).to be_truthy
+    context 'when wrap double quotes' do
+      it 'should wrap in double quotes' do
+        code = subject.cmd_psh_payload(payload, arch, template_path, wrap_double_quotes: true, method: psh_method)
+        expect(code.include?(' -c "')).to be_truthy
       end
     end
   end
@@ -393,12 +393,12 @@ RSpec.describe Rex::Powershell::Command do
           expect(long_args[-1]).not_to eql " "
 
           if opts[:command]
-            if opts[:use_single_quotes]
-              expect(long_args[-10..-1]).to eql "-Command Z"
-              expect(short_args[-4..-1]).to eql "-c Z"
-            else
+            if opts[:wrap_double_quotes]
               expect(long_args[-12..-1]).to eql "-Command \"Z\""
               expect(short_args[-6..-1]).to eql "-c \"Z\""
+            else
+              expect(long_args[-10..-1]).to eql "-Command Z"
+              expect(short_args[-4..-1]).to eql "-c Z"
             end
           end
        end


### PR DESCRIPTION
Implement alternatives to IEX-style invocation in the download and exec string methods.
Cleanup redundant escape for single quotes option in command composition.