### PR TITLE
Update GetMethod for GetProcAddress for Windows 10 1803

### DIFF
--- a/data/templates/to_mem_pshreflection.ps1.template
+++ b/data/templates/to_mem_pshreflection.ps1.template
@@ -2,7 +2,7 @@ function %{func_get_proc_address} {
 	Param ($%{var_module}, $%{var_procedure})		
 	$%{var_unsafe_native_methods} = ([AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.GlobalAssemblyCache -And $_.Location.Split('\\')[-1].Equals('System.dll') }).GetType('Microsoft.Win32.UnsafeNativeMethods')
 	
-	return $%{var_unsafe_native_methods}.GetMethod('GetProcAddress').Invoke($null, @([System.Runtime.InteropServices.HandleRef](New-Object System.Runtime.InteropServices.HandleRef((New-Object IntPtr), ($%{var_unsafe_native_methods}.GetMethod('GetModuleHandle')).Invoke($null, @($%{var_module})))), $%{var_procedure}))
+	return $%{var_unsafe_native_methods}.GetMethod('GetProcAddress', [Type[]]@([System.Runtime.InteropServices.HandleRef], [String])).Invoke($null, @([System.Runtime.InteropServices.HandleRef](New-Object System.Runtime.InteropServices.HandleRef((New-Object IntPtr), ($%{var_unsafe_native_methods}.GetMethod('GetModuleHandle')).Invoke($null, @($%{var_module})))), $%{var_procedure}))
 }
 
 function %{func_get_delegate_type} {


### PR DESCRIPTION
Windows 10 1803 adds an override on GetProcAddress that accepts a pointer to a handle, so we need to specify which function override we want. We can do this by supplying an array of argument types we want.

Solution from:
https://github.com/EmpireProject/Empire/pull/1146

Fix:
https://github.com/rapid7/metasploit-framework/issues/10032
