### PR TITLE
Add option to use rc4 encoding

### DIFF
--- a/lib/rex/powershell/command.rb
+++ b/lib/rex/powershell/command.rb
@@ -298,6 +298,8 @@ EOS
         Rex::Powershell::Payload.to_win32pe_psh(template_path, pay)
       when 'msil'
         Rex::Powershell::Payload.to_win32pe_psh_msil(template_path, pay)
+      when 'rc4'
+        Rex::Powershell::Payload.to_win32pe_psh_rc4(template_path, pay)
       else
         fail RuntimeError, 'No Powershell method specified'
     end


### PR DESCRIPTION
This is a first step to supporting https://github.com/rapid7/metasploit-framework/pull/11257 by adding the option to use rc4 encoding.  Together, they are still broken, so I am marking this as a draft.  Please see the framework PR at https://github.com/rapid7/metasploit-framework/pull/11257 for testing strategies.