### PR TITLE
Update command.rb to add in support for the -version flag of Powershell

### DIFF
--- a/lib/rex/powershell/command.rb
+++ b/lib/rex/powershell/command.rb
@@ -123,6 +123,8 @@ module Command
   #   powershell profile (-NoProfile)
   # @option opts [String] :windowstyle The window style to use
   #   (-WindowStyle)
+  # @option opts [String] :version The version of Powershell to run
+  #   (-version)
   #
   # @return [String] Powershell command arguments
   def self.generate_psh_args(opts)
@@ -157,6 +159,8 @@ module Command
           arg_string << '-NoProfile ' if value
         when :windowstyle
           arg_string << "-WindowStyle #{value} " if value
+        when :version
+          arg_string << "-Version #{value} " if value
       end
     end
 
@@ -188,6 +192,7 @@ module Command
       arg_string.gsub!('-OutputFormat ', '-o ')
       arg_string.gsub!('-Sta ', '-s ')
       arg_string.gsub!('-WindowStyle ', '-w ')
+      arg_string.gsub!('-Version ', '-v ')
     end
 
     # Strip off first space character

--- a/spec/rex/powershell/command_spec.rb
+++ b/spec/rex/powershell/command_spec.rb
@@ -361,6 +361,7 @@ RSpec.describe Rex::Powershell::Command do
                     [:sta, true],
                     [:noprofile, true],
                     [:windowstyle, "hidden"],
+                    [:version, "2.0"],
                     [:command, "Z"],
                     [:wrap_double_quotes, true]
     ]


### PR DESCRIPTION
This is largely based off of the work of @wo4haoren's PR at https://github.com/rapid7/rex-powershell/pull/24 which I unfortunately had to close as it came from his `master` branch, however I take no credit for the work he has done so far. All this PR does is expand his work a little bit to add in support for specifying any version of PowerShell to be run, instead of just version 2.0, and also adds in an RSpec test.

I have never done RSpec before though so this check may be entirely wrong. I tried to model it off of what I saw the rest of the `spec/rex/powershell/command_spec.rb` file doing but it may be completely wrong. Would appreciate input on that.

For testing please verify the code looks correct and that the RSpec tests run as expected.