### PR TITLE
Add check for rc4 wrapper and code to implement

### DIFF
--- a/lib/rex/powershell/command.rb
+++ b/lib/rex/powershell/command.rb
@@ -306,7 +306,9 @@ EOS
       else
         fail RuntimeError, 'No Powershell method specified'
     end
-
+    if opts[:exec_rc4]
+      psh_payload = Rex::Powershell::Payload.to_win32pe_psh_rc4(template_path, psh_payload)
+    end
     # Run our payload in a while loop
     if opts[:persist]
       fun_name = Rex::Text.rand_text_alpha(rand(2) + 2)


### PR DESCRIPTION
The original PR here: https://github.com/rapid7/rex-powershell/pull/23 was incorrect because my local git settings were wrong when I put it up.  Rather than argue with git, here's a fixed version.  You will need 
https://github.com/rapid7/metasploit-framework/pull/11257
@smcintyre-r7 

# Testing
- [x] Start msfconsole
- [x] use exploit/windows/smb/psexec
- [x] do the settings
- [x] set payload windows/x64/meterpreter/reverse_tcp
- [x] set powershell::exec_rc4 false
- [x] run
- [x] verify you get a session
- [x] set powershell::exec_rc4 true
- [x] run
- [x] verify you get a session
- [x] set payload windows/powershell_reverse_tcp
- [x] set powershell::exec_rc4 false
- [x] run
- [ ] verify no errors for payload size (this will fail for other reasons  right now, though)
- [x] set powershell::exec_rc4 true
- [x] run
- [x] verify failure because the size is too large

