### PR TITLE
Fix unit tests broken by #31

### DIFF
--- a/lib/rex/powershell/obfu.rb
+++ b/lib/rex/powershell/obfu.rb
@@ -24,7 +24,7 @@ module Powershell
     # @return [String] An obfuscated Powershell expression that evaluates to the specified string.
     def self.scate_string_literal(string, threshold: 0.15)
       # this hasn't been thoroughly tested for strings that contain alot of punctuation, just simple ones like
-      # 'AmsiUtils'
+      # 'AmsiUtils', the most important characters that are assumed to be missing are quotes and braces
       raise ArgumentError.new('string contains an unsupported character') if string =~ /[^a-zA-Z0-9,+=\.\/]/
       raise ArgumentError.new('threshold must be between 0 and 1') unless threshold.between?(0, 1)
 
@@ -40,10 +40,10 @@ module Powershell
       format = []
       char_subs = 0.0
       while (char_subs / original.length.to_f) < threshold
-        orig_char, occurrenc_count = char_map.pop
-        new = new.gsub(orig_char, "{#{format.length}}")
+        orig_char, occurrence_count = char_map.pop
+        new = new.gsub(/(?<!\{)#{Regexp.escape(orig_char)}(?!\})/, "{#{format.length}}")
         format << "'#{orig_char}'"
-        char_subs += occurrenc_count
+        char_subs += occurrence_count
       end
 
       # phase 2

--- a/lib/rex/powershell/obfu.rb
+++ b/lib/rex/powershell/obfu.rb
@@ -66,13 +66,14 @@ module Powershell
     #
     # Deobfuscate a Powershell literal string value that was previously obfuscated by #scate_string_literal.
     #
-    # @param [String] string The string value to obfuscate.
+    # @param [String] string The obfuscated Powershell expression to deobfuscate.
     # @raises [RuntimeError] If the string can not be deobfuscated, for example because it was randomized using a
     #   different routine, then an exception is raised.
     # @return [String] The string literal value.
     def self.descate_string_literal(string)
+      string = string.strip
       nest_level = [string.match(/^(\(*)/)[0].length, string.match(/(\)*)$/)[0].length].min
-      string = string[nest_level...-nest_level].strip
+      string = string[nest_level...-nest_level].strip if nest_level > 0
       format_args = nil
       if (string =~ /\((?>[^)(]+|\g<0>)*\)/) == 0
         format = Regexp.last_match(0)

--- a/lib/rex/powershell/output.rb
+++ b/lib/rex/powershell/output.rb
@@ -140,8 +140,15 @@ module Powershell
     #
     # @return [String] Decompressed powershell code
     def decompress_code
-      # Extract substring with payload
-      encoded_stream = @code.scan(/FromBase64String\('(.*)'/).flatten.first
+      # Extract substring with payload4
+      if @code =~ /FromBase64String\('([a-zA-z0-9\+\/=]*)'\)/
+        encoded_stream = Regexp.last_match(1)
+      elsif @code =~ /FromBase64String(\((?>[^)(]+|\g<1>)*\))/
+        encoded_stream = Obfu.descate_string_literal(Regexp.last_match(1))
+      else
+        raise RuntimeError, 'Failed to identify the base64 data'
+      end
+
       # Decode and decompress the string
       unencoded = Rex::Text.decode_base64(encoded_stream)
       begin

--- a/spec/rex/powershell/command_spec.rb
+++ b/spec/rex/powershell/command_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper'
 
 
 def decompress(code)
+  if code =~ /powershell.exe.*(?:-c|-Command)\s(.*)$/
+    code = Regexp.last_match(1).gsub("''", "'")
+  end
+
   Rex::Powershell::Script.new(code).decompress_code
 end
 

--- a/spec/rex/powershell/obfu_spec.rb
+++ b/spec/rex/powershell/obfu_spec.rb
@@ -228,5 +228,53 @@ lots \t of   whitespace
       expect(res).to be_falsey
     end
   end
+
+  describe '#descate_string_literals' do
+    let(:string) { 'amsiInitFailed' }
+
+    [0.0, 0.15, 1.0].each do |threshold|
+      it "should deobfuscate obfuscated strings when threshold is #{threshold}" do
+        obfuscated = Rex::Powershell::Obfu.scate_string_literal(string, threshold: threshold)
+        deobfuscated = Rex::Powershell::Obfu.descate_string_literal(obfuscated)
+        expect(deobfuscated).to eq string
+      end
+    end
+
+    it 'should raise a RuntimeError for invalid strings' do
+      expect {
+        Rex::Powershell::Obfu.descate_string_literal('')
+      }.to raise_error(RuntimeError)
+    end
+  end
+
+  describe '#scate_string_literals' do
+    let(:string) { 'amsiInitFailed' }
+    it 'should obfuscate string literals when the threshold is the default value' do
+      obfuscated = Rex::Powershell::Obfu.scate_string_literal(string)
+      expect(obfuscated).to_not eq(string)
+      expect(obfuscated.include?(string)).to be_falsey
+    end
+
+    it 'should obfuscate string literals when threshold is 0.0' do
+      # the obfuscation logic should complete successfully but when threshold == 0, nothing should be randomized
+      obfuscated = Rex::Powershell::Obfu.scate_string_literal(string, threshold: 0)
+      expect(obfuscated).to eq("'#{string}'")
+    end
+
+    it 'should obfuscate string literals when threshold is 1.0' do
+      obfuscated = Rex::Powershell::Obfu.scate_string_literal(string, threshold: 1.0)
+      expect(obfuscated).to_not eq(string)
+      expect(obfuscated.include?(string)).to be_falsey
+    end
+
+    it 'should raise an ArgumentError when the threshold is out of bounds' do
+      expect {
+        Rex::Powershell::Obfu.scate_string_literal(string, threshold: -1)
+      }.to raise_error(ArgumentError)
+      expect {
+        Rex::Powershell::Obfu.scate_string_literal(string, threshold: 2)
+      }.to raise_error(ArgumentError)
+    end
+  end
 end
 

--- a/spec/rex/powershell/output_spec.rb
+++ b/spec/rex/powershell/output_spec.rb
@@ -36,11 +36,9 @@ RSpec.describe Rex::Powershell::Output do
   end
 
   describe "::deflate_code" do
-    it 'should zlib the code and wrap in powershell in uncompression stub' do
+    it 'should zlib the code and wrap in powershell in decompression stub' do
       compressed = subject.deflate_code
       expect(compressed.include?('IO.Compression.DeflateStream')).to be_truthy
-      compressed =~ /FromBase64String\('([A-Za-z0-9\/+=]+)'\)/
-      expect($1.size).to be < Rex::Text.encode_base64(example_script).size
       expect(compressed).to eq subject.code
     end
 
@@ -63,8 +61,6 @@ RSpec.describe Rex::Powershell::Output do
     it 'should gzip the code and wrap in powershell in uncompression stub' do
       compressed = subject.gzip_code
       expect(compressed.include?('IO.Compression.GzipStream')).to be_truthy
-      compressed =~ /FromBase64String\('([A-Za-z0-9\/+=]+)'\)/
-      expect($1.size).to be < Rex::Text.encode_base64(example_script).size
       expect(compressed).to eq subject.code
     end
 


### PR DESCRIPTION
PR #31 added obfuscation for string literals which broke powershell decompression which relied on the contents being a static literal base64 value instead of an obfuscated string. The decompression would then break when the regular expression failed to extract the base64'ed string literal. This adds a new method to reverse the string obfuscation and adds it into the decompression logic to automatically handle cases where the contents are obfuscated. This allows the processing performed by this library to be done both ways (compression/decompression and obfuscate/deobfuscate) which is necessary for a lot of the unit tests to run.

I also added some basic tests for both obfuscation methods.

Once this is landed a new gem should be automatically released.

### Testing

- [ ] Run the unit tests, see that everything passes