### PR TITLE
Add Powershell Specific Errors

### DIFF
--- a/lib/rex/powershell.rb
+++ b/lib/rex/powershell.rb
@@ -1,5 +1,6 @@
 # -*- coding: binary -*-
 require 'rex/powershell/version'
+require 'rex/powershell/exceptions'
 require 'rex/powershell/output'
 require 'rex/powershell/parser'
 require 'rex/powershell/obfu'

--- a/lib/rex/powershell/command.rb
+++ b/lib/rex/powershell/command.rb
@@ -293,11 +293,11 @@ EOS
   # @return [String] Powershell command line with payload
   def self.cmd_psh_payload(pay, payload_arch, template_path, opts = {})
     if opts[:encode_inner_payload] && opts[:encode_final_payload]
-      fail RuntimeError, ':encode_inner_payload and :encode_final_payload are incompatible options'
+      fail Exceptions::PowershellError, ':encode_inner_payload and :encode_final_payload are incompatible options'
     end
 
     if opts[:no_equals] && !opts[:encode_final_payload]
-      fail RuntimeError, ':no_equals requires :encode_final_payload option to be used'
+      fail Exceptions::PowershellError, ':no_equals requires :encode_final_payload option to be used'
     end
 
     psh_payload = case opts[:method]
@@ -310,7 +310,7 @@ EOS
       when 'msil'
         Rex::Powershell::Payload.to_win32pe_psh_msil(template_path, pay)
       else
-        fail RuntimeError, 'No Powershell method specified'
+        fail Exceptions::PowershellError, 'No Powershell method specified'
     end
 
     if opts[:exec_rc4]
@@ -405,7 +405,7 @@ EOS
     end
 
     if command.length > 8191
-      fail RuntimeError, 'Powershell command length is greater than the command line maximum (8192 characters)'
+      fail Exceptions::PowershellCommandLengthError, 'Powershell command length is greater than the command line maximum (8192 characters)'
     end
 
     command

--- a/lib/rex/powershell/exceptions.rb
+++ b/lib/rex/powershell/exceptions.rb
@@ -1,0 +1,16 @@
+# -*- coding: binary -*-
+
+module Rex
+module Powershell
+module Exceptions
+
+  class PowershellError < RuntimeError
+  end
+
+  class PowershellCommandLengthError < PowershellError
+  end
+
+end
+end
+end
+

--- a/lib/rex/powershell/obfu.rb
+++ b/lib/rex/powershell/obfu.rb
@@ -67,7 +67,7 @@ module Powershell
     # Deobfuscate a Powershell literal string value that was previously obfuscated by #scate_string_literal.
     #
     # @param [String] string The obfuscated Powershell expression to deobfuscate.
-    # @raises [RuntimeError] If the string can not be deobfuscated, for example because it was randomized using a
+    # @raises [Exceptions::PowershellError] If the string can not be deobfuscated, for example because it was randomized using a
     #   different routine, then an exception is raised.
     # @return [String] The string literal value.
     def self.descate_string_literal(string)
@@ -79,14 +79,14 @@ module Powershell
         format = Regexp.last_match(0)
         format_args = string[format.length..-1].strip
         unless format_args =~ /-f\s*('.',\s*)*('.')/
-          raise RuntimeError.new('The obfuscated string structure is unsupported')
+          raise Exceptions::PowershellError, 'The obfuscated string structure is unsupported'
         end
         format_args = format_args[2..-1].strip.scan(/'(.)'/).map { |match| match[0] }
         string = format[1...-1].strip
       end
 
       unless string =~ /^'.*'$/
-        raise RuntimeError.new('The obfuscated string structure is unsupported')
+        raise Exceptions::PowershellError, 'The obfuscated string structure is unsupported'
       end
       string = string.gsub(/'\s*\+\s*'/, '') # process all concatenation operations
       unless format_args.nil? # process all format string operations

--- a/lib/rex/powershell/output.rb
+++ b/lib/rex/powershell/output.rb
@@ -146,7 +146,7 @@ module Powershell
       elsif @code =~ /FromBase64String(\((?>[^)(]+|\g<1>)*\))/
         encoded_stream = Obfu.descate_string_literal(Regexp.last_match(1))
       else
-        raise RuntimeError, 'Failed to identify the base64 data'
+        raise Exceptions::PowershellError, 'Failed to identify the base64 data'
       end
 
       # Decode and decompress the string
@@ -157,7 +157,7 @@ module Powershell
         begin
           @code = Rex::Text.zlib_inflate(unencoded)
         rescue Zlib::DataError => e
-          raise RuntimeError, 'Invalid compression'
+          raise Exceptions::PowershellError, 'Invalid compression'
         end
       end
 

--- a/spec/rex/powershell/command_spec.rb
+++ b/spec/rex/powershell/command_spec.rb
@@ -1,7 +1,6 @@
 # -*- coding:binary -*-
 require 'spec_helper'
 
-
 def decompress(code)
   if code =~ /powershell.exe.*(?:-c|-Command)\s(.*)$/
     code = Regexp.last_match(1).gsub("''", "'")
@@ -163,26 +162,19 @@ RSpec.describe Rex::Powershell::Command do
 
     context 'when payload is huge' do
       it 'should raise an exception' do
-        except = false
-        begin
-          code = subject.cmd_psh_payload(Rex::Text.rand_text_alpha(12000), arch, template_path, method: psh_method)
-        rescue RuntimeError => e
-          except = true
-        end
-
-        expect(except).to be_truthy
+        expect { subject.cmd_psh_payload(Rex::Text.rand_text_alpha(12000), arch, template_path, method: psh_method) }.to raise_error(Rex::Powershell::Exceptions::PowershellCommandLengthError)
       end
     end
 
     context 'when persist is true' do
-      it 'should add a persistance loop' do
+      it 'should add a persistence loop' do
         code = subject.cmd_psh_payload(payload, arch, template_path, persist: true, method: psh_method)
         expect(decompress(code).include?('while(1){Start-Sleep -s ')).to be_truthy
       end
     end
 
     context 'when persist is false' do
-      it 'shouldnt add a persistance loop' do
+      it 'should not add a persistence loop' do
         code = subject.cmd_psh_payload(payload, arch, template_path, persist: false, method: psh_method)
         expect(decompress(code).include?('while(1){Start-Sleep -s ')).to be_falsey
       end


### PR DESCRIPTION
This switches instances of `RuntimeError` to a module specific `PowershellError` class so callers can tell what's going on with a  bit more detail. This also uses a new error, when the generate command line maximum is exceeded. This can allow the caller to potentially handle it by adjusting options. No logic is changed and all modified exceptions are still derived from the original `RuntimeError`.

This will be needed by a Metasploit PR.