### PR TITLE
Fix upgrading sessions on Windows

### DIFF
--- a/lib/rex/powershell/script.rb
+++ b/lib/rex/powershell/script.rb
@@ -48,7 +48,7 @@ module Powershell
 
         # Close open file
         fd.close
-      rescue Errno::ENAMETOOLONG, Errno::ENOENT
+      rescue Errno::ENAMETOOLONG, Errno::ENOENT, Errno::EINVAL
         # Treat code as a... code
         @code = code.to_s.dup # in case we're eating another script
       end


### PR DESCRIPTION
This PR fixes https://github.com/rapid7/metasploit-framework/issues/15883

## Validation:

- [ ] Use msfconsole on a Windows machine
- [ ] Get an SSH shell against a target (TryHackMe's `Post-Exploitation Basics` in this case)
- [ ] `sessions -u -1`
- [ ] Confirm the session is upgraded to a Meterpreter session

## Before:
Crashing when upgrading a session.

## After:
Session is upgraded.