### PR TITLE
Updates to use powershell language opts

### DIFF
--- a/lib/rex/powershell/script.rb
+++ b/lib/rex/powershell/script.rb
@@ -14,7 +14,7 @@ module Powershell
     DEFAULT_RIG_OPTS = {
       max_length: 5,
       min_length: 2,
-      forbidden: Parser::RESERVED_VARIABLE_NAMES.map {|e| e[1..-1]}
+      language: :powershell
     }
     # Pretend we are actually a string
     extend ::Forwardable


### PR DESCRIPTION
Updates the script to make use of keywords for Powershell added as part of https://github.com/rapid7/rex-random_identifier/pull/17.

## Before 
It was manually defining its own limited forbidden list using the `Parser::RESERVED_VARIABLE_NAMES`.

## After
Now it uses the `language: :powershell` option, which tells rex-random_identifier to use the comprehensive `PowershellOpts` that includes:
- PowerShell language keywords
- .NET type names
- PowerShell automatic variables
- PowerShell cmdlet aliases

## Verification
- [ ] CI passes
